### PR TITLE
add icebreaker support

### DIFF
--- a/frameworks/icebreaker.v
+++ b/frameworks/icebreaker.v
@@ -1,0 +1,58 @@
+`define ICEBREAKER 1
+`default_nettype none
+$$ICEBREAKER=1
+$$HARDWARE=1
+
+module top(
+  input  CLK,
+  output LED1,
+  output LED2,
+  output LED3,
+  output LED4,
+  output LED5
+  );
+
+wire __main_d1;
+wire __main_d2;
+wire __main_d3;
+wire __main_d4;
+wire __main_d5;
+
+reg ready = 0;
+reg [31:0] RST_d;
+reg [31:0] RST_q;
+
+always @* begin
+  RST_d = RST_q >> 1;
+end
+
+always @(posedge CLK) begin
+  if (ready) begin
+    RST_q <= RST_d;
+  end else begin
+    ready <= 1;
+    RST_q <= 32'b111111111111111111111111111111;
+  end
+end
+
+wire run_main;
+assign run_main = 1'b1;
+
+M_main __main(
+  .clock(CLK),
+  .reset(RST_d),
+  .out_led0(__main_d1),
+  .out_led1(__main_d2),
+  .out_led2(__main_d3),
+  .out_led3(__main_d4),
+  .out_led4(__main_d5),
+  .in_run(run_main)
+);
+
+assign LED1 = __main_d1;
+assign LED2 = __main_d2;
+assign LED3 = __main_d3;
+assign LED4 = __main_d4;
+assign LED5 = __main_d5;
+
+endmodule

--- a/frameworks/icebreaker_vga.v
+++ b/frameworks/icebreaker_vga.v
@@ -1,0 +1,115 @@
+`define ICEBREAKER 1
+`default_nettype none
+$$ICEBREAKER=1
+$$HARDWARE=1
+$$VGA=1
+$$color_depth=6
+$$color_max  =63
+$$config['bram_wenable_width'] = 'data'
+$$config['dualport_bram_wenable0_width'] = 'data'
+$$config['dualport_bram_wenable1_width'] = 'data'
+
+module top(
+  input  CLK,
+  output LED1,
+  output LED2,
+  output LED3,
+  output LED4,
+  output LED5,
+
+  output P1A1, // r0
+  output P1A2, // r1
+  output P1A3, // r2
+  output P1A4, // r3
+  
+  output P1A7,   // b0
+  output P1A8,   // b1
+  output P1A9,   // b2
+  output P1A10,  // b3
+  
+  output P1B1,  // g0
+  output P1B2,  // g1
+  output P1B3,  // g2
+  output P1B4,  // g3
+  
+  output P1B7, // hs
+  output P1B8  // vs
+  );
+
+wire __main_d1;
+wire __main_d2;
+wire __main_d3;
+wire __main_d4;
+wire __main_d5;
+
+wire __main_out_vga_hs;
+wire __main_out_vga_vs;
+wire __main_out_vga_v0;
+wire [5:0] __main_out_vga_r;
+wire [5:0] __main_out_vga_g;
+wire [5:0] __main_out_vga_b;
+
+wire clk_out;
+
+reg ready = 0;
+reg [31:0] RST_d;
+reg [31:0] RST_q;
+
+always @* begin
+  RST_d = RST_q >> 1;
+end
+
+always @(posedge clk_out) begin
+  if (ready) begin
+    RST_q <= RST_d;
+  end else begin
+    ready <= 1;
+    RST_q <= 32'b111111111111111111111111111111;
+  end
+end
+
+wire run_main;
+assign run_main = 1'b1;
+
+M_main __main(
+  .out_ctrl_clk(clk_out),
+  .clock(CLK),
+  .reset(RST_d[0]),
+  .out_led0(__main_d1),
+  .out_led1(__main_d2),
+  .out_led2(__main_d3),
+  .out_led3(__main_d4),
+  .out_led4(__main_d5),
+  .out_video_hs(__main_out_vga_hs),
+  .out_video_vs(__main_out_vga_vs),
+  .out_video_r(__main_out_vga_r),
+  .out_video_g(__main_out_vga_g),
+  .out_video_b(__main_out_vga_b),
+  .in_run(run_main)
+);
+
+assign LED1 = __main_d1;
+assign LED2 = __main_d2;
+assign LED3 = __main_d3;
+assign LED4 = __main_d4;
+assign LED5 = __main_d5;
+
+assign P1A1  = __main_out_vga_r[2+:1];
+assign P1A2  = __main_out_vga_r[3+:1];
+assign P1A3  = __main_out_vga_r[4+:1];
+assign P1A4  = __main_out_vga_r[5+:1];
+
+assign P1A7  = __main_out_vga_b[2+:1];
+assign P1A8  = __main_out_vga_b[3+:1];
+assign P1A9  = __main_out_vga_b[4+:1];
+assign P1A10 = __main_out_vga_b[5+:1];
+
+assign P1B1  = __main_out_vga_g[2+:1];
+assign P1B2  = __main_out_vga_g[3+:1];
+assign P1B3  = __main_out_vga_g[4+:1];
+assign P1B4  = __main_out_vga_g[5+:1];
+
+assign P1B7  = __main_out_vga_hs;
+assign P1B8  = __main_out_vga_vs;
+
+endmodule

--- a/projects/README.md
+++ b/projects/README.md
@@ -19,7 +19,7 @@ A few projects rely on some external hardware (typical, low cost things: OLED, k
 
 ## Building the examples
 
-All examples are in the *projects* directory. This directory also contains a *build* subdirectory, with one entry for each currently supported framework. This includes both simulation (icarus, verilator) and FPGA hardware (icestick, mojo v3, de10nano, etc.).
+All examples are in the *projects* directory. This directory also contains a *build* subdirectory, with one entry for each currently supported framework. This includes both simulation (icarus, verilator) and FPGA hardware (icestick, icebreaker, mojo v3, de10nano, etc.).
 
 To build a project, go into projects/build/*architecture* where *architecture* is your target framework. This directory contains shell scripts that take as parameter the project source file. Let's take an example! We will build the 'divint bare' demo for simulation with icarus. Do the following:
 

--- a/projects/build/icebreaker/icebreaker.pcf
+++ b/projects/build/icebreaker/icebreaker.pcf
@@ -1,0 +1,69 @@
+# ----------------------------------------------------------------------------
+#
+# Icebreaker constraint file (.pcf)
+# Pinout:
+# https://github.com/icebreaker-fpga/icebreaker/blob/master/img/icebreaker-v1_0b-legend.jpg
+# Link
+# https://1bitsquared.com/collections/fpga/products/icebreaker
+#
+# ----------------------------------------------------------------------------
+
+# -------------------------- SYSTEM CLOCK ------------------------------------
+set_io -nowarn CLK 35
+
+# ------------------------------ UART ----------------------------------------
+set_io -nowarn RX 6
+set_io -nowarn TX 9
+
+# ------------------------- LEDs and Button ----------------------------------
+set_io -nowarn BTN_N      10
+set_io -nowarn LEDR_N     11
+set_io -nowarn LEDG_N     37
+
+# --------------------------- SPI Flash --------------------------------------
+set_io -nowarn FLASH_SCK  15
+set_io -nowarn FLASH_SSB  16
+set_io -nowarn FLASH_IO0  14
+set_io -nowarn FLASH_IO1  17
+set_io -nowarn FLASH_IO2  12
+set_io -nowarn FLASH_IO3  13
+
+# ------------ Leds and Buttons (PMOD 2) -------------------------------------
+set_io -nowarn LED1 26
+set_io -nowarn LED2 27
+set_io -nowarn LED3 25
+set_io -nowarn LED4 23
+set_io -nowarn LED5 21
+set_io -nowarn BTN1 20
+set_io -nowarn BTN2 19
+set_io -nowarn BTN3 18
+
+# ------------ PMOD1A connector ----------------------------------------------
+set_io -nowarn P1A1   4
+set_io -nowarn P1A2   2
+set_io -nowarn P1A3  47
+set_io -nowarn P1A4  45
+set_io -nowarn P1A7   3
+set_io -nowarn P1A8  48
+set_io -nowarn P1A9  46
+set_io -nowarn P1A10 44
+
+# ------------ PMOD1B connector ----------------------------------------------
+set_io -nowarn P1B1  43
+set_io -nowarn P1B2  38
+set_io -nowarn P1B3  34
+set_io -nowarn P1B4  31
+set_io -nowarn P1B7  42
+set_io -nowarn P1B8  36
+set_io -nowarn P1B9  32
+set_io -nowarn P1B10 28
+
+# ------------ Leds and Buttons (PMOD 2) -------------------------------------
+set_io -nowarn P2_1  27
+set_io -nowarn P2_2  25
+set_io -nowarn P2_3  21
+set_io -nowarn P2_4  19
+set_io -nowarn P2_7  26
+set_io -nowarn P2_8  23
+set_io -nowarn P2_9  20
+set_io -nowarn P2_10 18

--- a/projects/build/icebreaker/icebreaker_bare.sh
+++ b/projects/build/icebreaker/icebreaker_bare.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export PATH=$PATH:$DIR/../../../bin/:$DIR/../../../tools/fpga-binutils/mingw32/bin/
+export PYTHONHOME=/mingw32/bin
+export PYTHONPATH=/mingw32/lib/python3.8/
+
+rm build*
+
+silice -f ../../../frameworks/icebreaker.v $1 -o build.v
+
+# exit
+
+yosys -q -p "synth_ice40 -json build.json" build.v
+nextpnr-ice40 --up5k --package sg48 --freq 13 --json build.json --pcf icebreaker.pcf --asc build.asc
+icepack build.asc build.bin
+
+iceprog build.bin

--- a/projects/build/icebreaker/icebreaker_vga.sh
+++ b/projects/build/icebreaker/icebreaker_vga.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export PATH=$PATH:$DIR/../../../bin/:$DIR/../../../tools/fpga-binutils/mingw32/bin/
+export PYTHONHOME=/mingw32/bin
+export PYTHONPATH=/mingw32/lib/python3.8/
+
+rm build*
+
+silice -f ../../../frameworks/icebreaker_vga.v $1 -o build.v
+
+# exit
+
+yosys -q -p "synth_ice40 -json build.json" build.v
+nextpnr-ice40 --up5k --package sg48 --json build.json --pcf icebreaker.pcf --asc build.asc
+icepack build.asc build.bin
+
+iceprog build.bin

--- a/projects/common/icebreaker_clk_25.v
+++ b/projects/common/icebreaker_clk_25.v
@@ -1,0 +1,28 @@
+module icebreaker_clk_25(     
+  input  clock_in,
+  output clock_out
+);
+
+  SB_PLL40_PAD #(.FEEDBACK_PATH("SIMPLE"),
+                  .PLLOUT_SELECT("GENCLK"),
+                  .DIVR(4'b0000),
+                  .DIVF(7'b1000010),
+                  .DIVQ(3'b101),
+                  .FILTER_RANGE(3'b001),
+                  .DELAY_ADJUSTMENT_MODE_FEEDBACK("FIXED"),
+                  .FDA_FEEDBACK(4'b0000),
+                  .DELAY_ADJUSTMENT_MODE_RELATIVE("FIXED"),
+                  .FDA_RELATIVE(4'b0000),
+                  .SHIFTREG_DIV_MODE(2'b00),
+                  .ENABLE_ICEGATE(1'b0)
+                 ) uut (
+                         .PACKAGEPIN(clock_in),
+                         .PLLOUTCORE(clock_out),
+                         .EXTFEEDBACK(),
+                         .DYNAMICDELAY(),
+                         .LATCHINPUTVALUE(),
+                         .RESETB(1'b1),
+                         .BYPASS(1'b0)
+                        );
+
+endmodule

--- a/projects/vga_demo/vga_demo_main.ice
+++ b/projects/vga_demo/vga_demo_main.ice
@@ -10,6 +10,11 @@ $$if MOJO then
 import('../common/mojo_clk_100_25.v')
 $$end
 
+$$if ICEBREAKER then
+// Clock
+import('../common/icebreaker_clk_25.v')
+$$end
+
 $$if ICESTICK then
 // Clock
 import('../common/icestick_clk_25.v')
@@ -83,12 +88,15 @@ $$end
 $$if SIMULATION then
   output! uint1 video_clock,
 $$end
-$$if ICESTICK then
+$$if ICESTICK or ICEBREAKER then
   output! uint1 led0,
   output! uint1 led1,
   output! uint1 led2,
   output! uint1 led3,
   output! uint1 led4,
+$$if ICEBREAKER then
+  output! uint1 ctrl_clk,
+$$end
 $$end
 $$if DE10NANO then
   output! uint8 led,
@@ -136,6 +144,12 @@ $$if MOJO then
     rcclk <: sdram_clock,
     in  <: reset,
     out :> sdram_reset
+  );
+$$elseif ICEBREAKER then
+  // --- clock
+  icebreaker_clk_25 clk_gen (
+    clock_in  <: clock,
+    clock_out :> video_clock
   );
 $$elseif ICESTICK then
   // --- clock
@@ -196,6 +210,10 @@ $$end
   );
 
   uint8 frame  = 0;
+
+$$if ICEBREAKER then
+  ctrl_clk = video_clock;
+$$end
 
 $$if MOJO then
   // unused pins


### PR DESCRIPTION
[1bitsquare iCEBreaker](https://1bitsquared.com/collections/fpga/products/icebreaker) is based on iCE40 UltraPlus 5K
with:
- 128Mbit of flash
- 3 PMOD
- 2 to 7 leds
- FT2232 for configuration and communication

Tested with all vga_demo example by using digilentinc PmodVGA extension.
Note:
- clk signal is connected to a dedicated pin an SB_PLL40_PAD is required this why it's required to ascend the clock after the PLL for reset
- most example have an hardcoded 6bits per colors -> drop 2 LSB to match pmodVGA 4 bits/color.