### PR TITLE
RFC: use edalize

### DIFF
--- a/frameworks/boards/icebreaker/board.json
+++ b/frameworks/boards/icebreaker/board.json
@@ -21,9 +21,18 @@
     {
       "system" : "shell",
       "command" : "icebreaker.sh",
-      "description": "Custom shell scripts using yosys and nextpnr"
+      "description": "Custom shell scripts using yosys and nextpnr",
+      "tool": "icestorm",
+      "tool_options": [
+        {
+            "nextpnr_options": ["--up5k", "--freq 13", "--package sg48"],
+            "pnr": "next"
+        }
+      ]
     }
   ],
+  "program": [{"cmd" : "iceprog", "bit_format" : "bin"}],
+  "constraints": [{"name": "icebreaker.pcf", "file_type": "PCF"}],
   "pins": {
     "bare": [
         {


### PR DESCRIPTION
This is a proof of concept of using `edalize`:
- `silice-make.py` handle everything instead of delegate task to dedicated scripts
  - `silice` is called using `subprocess`
  - board.json is updated to provide name and options for synthesys and PNR tools, constraints file and programmer tool
  - using this previous information, `silice-make.py` build an `edalize` backend according to the board to generate bitstream
  - again using json the dedicated tool is used if provided

This modification has been only tested with linux with icebreaker board.
One additional idea is to move all informations in frameworks/board/boards.json. Thanks to that, only verilog file(s) and constraints must be left