### PR TITLE
ULX3S Audio support

### DIFF
--- a/frameworks/boards/ulx3s/ulx3s.sh
+++ b/frameworks/boards/ulx3s/ulx3s.sh
@@ -37,6 +37,8 @@ yosys -p 'scratchpad -copy abc9.script.flow3 abc9.script; synth_ecp5 -abc9 -json
 
 nextpnr-ecp5 --85k --package CABGA381 --freq 25 --json build.json --textcfg build.config --lpf $BOARD_DIR/ulx3s.lpf --timing-allow-fail
 
+sed -i '/.sysconfig/d' build.config
+
 ecppack --compress --svf-rowsize 100000 --svf build.svf build.config build.bit
 
 fujprog build.bit

--- a/frameworks/boards/ulx3s/ulx3s.v
+++ b/frameworks/boards/ulx3s/ulx3s.v
@@ -59,7 +59,11 @@ module top(
   // uart
   output  ftdi_rxd,
   input   ftdi_txd,
-`endif  
+`endif
+
+  output [3:0] audio_l,
+  output [3:0] audio_r,
+
   input  clk_25mhz
   );
 
@@ -112,6 +116,9 @@ wire        __main_sd_mosi;
 wire [3:0]  __main_out_gpdi_dp;
 wire [3:0]  __main_out_gpdi_dn;
 `endif
+
+wire [3:0]  __main_out_audio_l;
+wire [3:0]  __main_out_audio_r;
 
 wire ready = btns[0];
 
@@ -184,6 +191,8 @@ M_main __main(
   .out_gpdi_dp  (__main_out_gpdi_dp),
   .out_gpdi_dn  (__main_out_gpdi_dn),
 `endif
+  .out_audio_l      (__main_out_audio_l),
+  .out_audio_r      (__main_out_audio_r),
   .clock         (clk_25mhz)
 );
 
@@ -251,5 +260,8 @@ assign ftdi_rxd      = __main_out_uart_tx;
 assign gpdi_dp       = __main_out_gpdi_dp;
 assign gpdi_dn       = __main_out_gpdi_dn;
 `endif
+
+assign audio_l          = __main_out_audio_l;
+assign audio_r          = __main_out_audio_r;
 
 endmodule


### PR DESCRIPTION
Audio support, via the 3.5mm jack for the ULX3S.

Added to ulx3s.v not protected by if-endif definitions. No changes to board.json file.

Tested and working.