### PR TITLE
silice-make.py: list-boards: add return after pin sets and fix horizontal alignment

### DIFF
--- a/bin/silice-make.py
+++ b/bin/silice-make.py
@@ -92,10 +92,11 @@ if args.list_boards:
             board_def = json.load(json_file)
             # list all variants
             for variant in board_def['variants']:
-                print('variant : ',colored(variant['name'], 'cyan'))
-                print('pin sets:  ',end='')
+                print('      variant : ',colored(variant['name'], 'cyan'))
+                print('      pin sets:  ',end='')
                 for pin_set in variant['pins']:
                     print(colored(pin_set['set'],'cyan'),' ',end='')
+                print()
     sys.exit(0)
 
 # check we have a board specified at this point


### PR DESCRIPTION
When `silice-make.py` displays available boards, the next *board name* and *description* is display in the same line then previous *pin sets*. To fix this a return line is added after the *pin_set loop*.

*board name* and *description* are horizontally aligned with 3 space but *variant* and *pin sets* are left aligned: 6 spaces are added to respect horizontal alignment and to have a better visual