### PR TITLE
frameworks: ulx3s: suppress the unconditionally present audio_x signals

### DIFF
--- a/frameworks/boards/ulx3s/ulx3s.v
+++ b/frameworks/boards/ulx3s/ulx3s.v
@@ -65,9 +65,6 @@ module top(
   input   ftdi_txd,
 `endif
 
-  output [3:0] audio_l,
-  output [3:0] audio_r,
-
   input  clk_25mhz
   );
 


### PR DESCRIPTION
ulx3s as an optional AUDIO set with audio_l and audio_r
In ulx3s.v these signals are added using `ifdef `endif when AUDIO set is set
But in the same time audio_l and audio_r are unconditionally present.