### PR TITLE
silice-make.py: add reprogram arg

### DIFF
--- a/bin/silice-make.py
+++ b/bin/silice-make.py
@@ -20,6 +20,7 @@ parser.add_argument('-r','--root', help="Root directory, use to override default
 parser.add_argument('--no_build', help="Only generate verilog output file.", action="store_true")
 parser.add_argument('--no_program', help="Only generate verilog output file and build bitstream.",
                     action="store_true")
+parser.add_argument('--reprogram', help="Only program device.", action="store_true")
 
 args = parser.parse_args()
 
@@ -250,49 +251,73 @@ elif target_builder['builder'] == 'edalize':
             'tool_options': {tool: target_builder["tool_options"][0]},
             'toplevel' : 'top',
             }
-    cmd = ["silice", "--frameworks_dir", frameworks_dir, "-f", framework_file, source_file, "-o", "build.v"]
-    for d in defines:
-        cmd.append("-D")
-        cmd.append(defines[d])
 
-    try:
-        subprocess.check_call(cmd, cwd=out_dir, env=my_env, stdin=subprocess.PIPE)
-    except FileNotFoundError as e:
-        raise RuntimeError("Unable to run script '{}': {}".format(cmd, str(e)))
-    except subprocess.CalledProcessError as e:
-        sys.exit(-1)
+    # check and adapt behavior
+    # reprogram imply to bypass build
+    if args.reprogram:
+        args.no_build = True
+        args.no_program = False
+        # check if output bitstream exist
+        try:
+            filename = target_builder["bitstream"]
+            bit_file = os.path.realpath(os.path.join(out_dir, filename))
+            print("* Bitstream file                : ",bit_file,"   ",end='')
+            if os.path.exists(bit_file):
+                print(colored("[ok]", 'green'))
+            else:
+                print(colored("[not found]", 'red'))
+                sys.exit(-1)
+
+        except KeyError as e:
+            pass # when bitstream is not in board.json try anyway
+    # no build imply no program
+    elif args.no_build:
+        args.no_program = True
+
+    if not args.reprogram:
+        cmd = ["silice", "--frameworks_dir", frameworks_dir, "-f", framework_file, source_file, "-o", "build.v"]
+        for d in defines:
+            cmd.append("-D")
+            cmd.append(defines[d])
+
+        try:
+            subprocess.check_call(cmd, cwd=out_dir, env=my_env, stdin=subprocess.PIPE)
+        except FileNotFoundError as e:
+            raise RuntimeError("Unable to run script '{}': {}".format(cmd, str(e)))
+        except subprocess.CalledProcessError as e:
+            sys.exit(-1)
 
     if not args.no_build:
         backend = get_edatool(tool)(edam=edam, work_root=out_dir)
         backend.configure()
         backend.build()
     
-        if not args.no_program:
-            try:
-                print(colored('programming device ... ','white', attrs=['bold']))
-                for program in target_builder['program']:
+    if not args.no_program:
+        try:
+            print(colored('programming device ... ','white', attrs=['bold']))
+            for program in target_builder['program']:
+                try:
+                    prog = program['cmd']
+                    args = program['args']
+                    cmd = [prog] + args.split(' ')
+                    str_cmd = ""
+                    for s in cmd:
+                        str_cmd = str_cmd + " " + s
                     try:
-                        prog = program['cmd']
-                        args = program['args']
-                        cmd = [prog] + args.split(' ')
-                        str_cmd = ""
-                        for s in cmd:
-                            str_cmd = str_cmd + " " + s
-                        try:
-                            subprocess.check_call(str_cmd, cwd=out_dir, env=my_env, stdin=subprocess.PIPE, shell=True)
-                        except FileNotFoundError as e:
-                            print(colored('<<error>>','red'))
-                            raise RuntimeError("Unable to run script '{}': {}".format(cmd, str(e)))
-                        except subprocess.CalledProcessError as e:
-                            print(colored('<<error>>','red'))
-                            raise RuntimeError("script '{}' exited with error code {}".format(
-                                cmd, e.returncode))
-                    except KeyError as e:
-                        print(colored('<<error in board.json>>','red'))
-                        raise RuntimeError("missing key {}".format(str(e)))
-                print(colored('done.','green'))
-            except KeyError as e:
-                print(colored('no programmer defined in json file','yellow'))
-            
+                        subprocess.check_call(str_cmd, cwd=out_dir, env=my_env, stdin=subprocess.PIPE, shell=True)
+                    except FileNotFoundError as e:
+                        print(colored('<<error>>','red'))
+                        raise RuntimeError("Unable to run script '{}': {}".format(cmd, str(e)))
+                    except subprocess.CalledProcessError as e:
+                        print(colored('<<error>>','red'))
+                        raise RuntimeError("script '{}' exited with error code {}".format(
+                            cmd, e.returncode))
+                except KeyError as e:
+                    print(colored('<<error in board.json>>','red'))
+                    raise RuntimeError("missing key {}".format(str(e)))
+            print(colored('done.','green'))
+        except KeyError as e:
+            print(colored('no programmer defined in json file','yellow'))
+
 else:
     print(colored("builder '" + target_variant_name + "' not implemented", 'red'))

--- a/frameworks/boards/crosslink_nx_evn/board.json
+++ b/frameworks/boards/crosslink_nx_evn/board.json
@@ -18,6 +18,7 @@
               "part": "LIFCL-40-9BG400C"
           }
         ],
+        "bitstream"  : "impl/build_impl.bit",
         "constraints": [{"name": "crosslink_nx_evn.pdc", "file_type": "PDC"}],
         "program": [{"cmd" : "openFPGALoader", "args" : "impl/build_impl.bit"}]
       },

--- a/frameworks/boards/de10nano/board.json
+++ b/frameworks/boards/de10nano/board.json
@@ -27,6 +27,7 @@
           }
         ],
         "toplevel" : "top",
+        "bitstream"  : "build.sof",
         "constraints": [
           {"name": "build.sdc", "file_type": "SDC"},
           {"name": "pins.tcl", "file_type": "tclSource"}

--- a/frameworks/boards/icebreaker/board.json
+++ b/frameworks/boards/icebreaker/board.json
@@ -21,6 +21,7 @@
                 "pnr": "next"
             }
           ],
+          "bitstream"  : "build.bin",
           "constraints": [{"name": "icebreaker.pcf", "file_type": "PCF"}],
           "program": [{"cmd" : "iceprog", "args" : "build.bin"}]
         },

--- a/frameworks/boards/icestick/board.json
+++ b/frameworks/boards/icestick/board.json
@@ -20,6 +20,7 @@
                 "pnr": "next"
             }
           ],
+          "bitstream"  : "build.bin",
           "constraints": [{"name": "icestick.pcf", "file_type": "PCF"}],
           "program": [{"cmd" : "iceprog", "args" : "build.bin"}]
         },

--- a/frameworks/boards/mojov3/board.json
+++ b/frameworks/boards/mojov3/board.json
@@ -21,6 +21,7 @@
           }
         ],
         "toplevel" : "top",
+        "bitstream"  : "top.bin",
         "constraints": [
           {"name": "mojov3.ucf", "file_type": "UCF"}
         ],

--- a/frameworks/boards/orangecrab/board.json
+++ b/frameworks/boards/orangecrab/board.json
@@ -18,6 +18,7 @@
                 "pnr": "next"
             }
           ],
+          "bitstream"  : "build.dfu",
           "constraints": [{"name": "pinout.lpf", "file_type": "LPF"}],
           "program": [
             {"cmd" : "cp", "args" : "build.bit build.dfu"},

--- a/frameworks/boards/ulx3s/board.json
+++ b/frameworks/boards/ulx3s/board.json
@@ -28,6 +28,7 @@
               "pnr": "next"
           }
         ],
+        "bitstream"  : "build.bit",
         "constraints": [{"name": "ulx3s.lpf", "file_type": "LPF"}],
         "program": [{"cmd" : "fujprog", "args" : "build.bit"}]
       },


### PR DESCRIPTION
It's sometime interesting to be able to reprogram a device without waiting for bitstream generation steps.

This PR add `--reprogram` option and simplify bypass steps:
- add a `bitstream` node in `board.json` to provide bitstream name
- when `reprogram` check if bitstream exist and display error message if not present
- fix `no_build` and `no_program` according to mode

The `bitstream` node may seems redundant with `cmd` `args` but it's not trivially possible to deduce command line in all case:
- `de10nano` use `p;bitstream_name@2` 
- `mojov3` has many cmd subnodes