### PR TITLE
Syntax highlighting for Silice on emacs

### DIFF
--- a/tools/emacs/silice-mode.el
+++ b/tools/emacs/silice-mode.el
@@ -1,0 +1,78 @@
+;;; silice-mode.el --- Major mode for Silice
+
+;;; Commentary:
+
+;; A major mode providing some syntax highlighting for the Silice programming language.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Dependency
+
+;;; Code:
+
+(defgroup silice nil
+  "Major mode for editing Silice code."
+  :link '(custom-group-link :tag "Font lock faces group" font-lock-faces)
+  :group 'languages)
+
+(defconst silice-font-lock-keywords
+  '(("\\b\\(uninitialized\\|import\\|algorithm\\|input\\|output\\|inout\\|if\\|else\\|while\\|autorun\\|auto\\|onehot\\|\\+\\+:\\|brom\\|bram\\|dualport_bram\\|case\\|default\\|break\\|switch\\|circuitry\\|always\\|bitfield\\|interface\\)\\b"
+     . font-lock-keyword-face)
+    ;; keywords
+    ("\\(@\\|!\\)\\([[:alpha:]]\\|_\\)\\([[:alnum:]]\\|_\\)+"
+     . font-lock-function-name-face)
+    ;; algorithm meta-specifiers
+    ("\\b\\(__\\(display\\|write\\|\\(un\\)?signed\\)\\)\\b"
+     . font-lock-builtin-face)
+    ;; intrisics
+    ("\\b\\(u?int\\([[:digit:]]+\\)?\\)\\b"
+     . font-lock-type-face)
+    ;; builtin types
+    ("\\(\\(^\\$\\$\\(.\\|[[:space:]]\\)*?$\\)\\|\\(^\\$include\\(.*?\\)$\\)\\|\\(\\$[^z-a]*?\\$\\)\\)"
+     . font-lock-preprocessor-face)
+    ;; preprocessor
+    ("\".*?\""
+     . font-lock-string-face)
+    ("'.*?'"
+     . font-lock-string-face)
+    ;; strings
+    ("[[:digit:]]+\\(b\\|h\\|d\\)[[:xdigit:]]+"
+     . font-lock-constant-face)
+    )
+  "Additional expressions to highlight in Silice mode.")
+
+(defvar silice-mode-syntax-table
+  (let ((st (make-syntax-table)))
+    (modify-syntax-entry ?\n "> b" st)
+    (modify-syntax-entry ?/  ". 124b" st)
+    (modify-syntax-entry ?*  ". 23" st)
+    (modify-syntax-entry ?_  "w" st)
+;    (modify-syntax-entry ?\" "|" st)
+;    (modify-syntax-entry ?'  "|" st)
+;    NOTE: this somehow breaks the font locks defined for the preprocessor if they contain strings
+    st)
+  "Syntax table used while in Silice mode.")
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.ice\\'" . silice-mode))
+;;;###autoload
+(define-derived-mode silice-mode prog-mode "Silice"
+  "Major mode for editing simple Silice source files.
+Only provides syntax highlighting."
+
+  (setq-local font-lock-defaults '(silice-font-lock-keywords))
+  (set-syntax-table (make-syntax-table silice-mode-syntax-table))
+
+  (setq-local comment-start "//")
+  (setq-local comment-add 1)
+  (setq-local comment-end "")
+
+  (setq-local comment-start-skip "\\(?:\\s<+\\|/[/*]+\\)[ \t]*")
+  (setq-local comment-end-skip "[ \t]*\\(\\s>\\|\\*+/\\)")
+
+  (setq-local comment-multi-line 1)
+  )
+
+
+(provide 'silice-mode)
+
+;;; silice-mode.el ends here

--- a/tools/emacs/silice-mode.el
+++ b/tools/emacs/silice-mode.el
@@ -16,7 +16,7 @@
 
 (defconst silice-font-lock-keywords
   '(("\\(\\(\\$\\$[^\n]*?$\\)\\|\\(\\$include\\([^\n]*?\\)$\\)\\|\\(\\$[^z-a]*?\\$\\)\\)"
-     . font-lock-preprocessor-face)
+     0 font-lock-preprocessor-face prepend)
     ;; preprocessor
     ("\\b\\(uninitiali\\(s|z\\)ed\\|import\\|algorithm\\|input\\|output\\|inout\\|if\\|else\\|while\\|autorun\\|auto\\|onehot\\|\\+\\+:\\|brom\\|bram\\|dualport_bram\\|case\\|default\\|break\\|switch\\|circuitry\\|always\\|bitfield\\|interface\\|subroutine\\|readwrites\\|reads\\|writes\\|calls\\)\\b"
      . font-lock-keyword-face)
@@ -50,8 +50,8 @@
     (modify-syntax-entry ?*  ". 23" st)
     (modify-syntax-entry ?_  "w" st)
     (modify-syntax-entry ?$  "_" st)
-;    (modify-syntax-entry ?\" "|" st)
-;    (modify-syntax-entry ?'  "|" st)
+    (modify-syntax-entry ?\" "|" st)
+    (modify-syntax-entry ?'  "|" st)
 ;    NOTE: this somehow breaks the font locks defined for the preprocessor if they contain strings
     st)
   "Syntax table used while in Silice mode.")
@@ -61,11 +61,11 @@
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.ice\\'" . silice-mode))
 ;;;###autoload
-(define-derived-mode silice-mode fundamental-mode "Silice"
+(define-derived-mode silice-mode prog-mode "Silice"
   "Major mode for editing simple Silice source files.
 Only provides syntax highlighting."
+  :syntax-table silice-mode-syntax-table
 
-  (set-syntax-table (make-syntax-table silice-mode-syntax-table))
   (setq-local font-lock-defaults '(silice-font-lock-keywords))
 
   (setq-local comment-start "//")

--- a/tools/emacs/silice-mode.el
+++ b/tools/emacs/silice-mode.el
@@ -15,13 +15,13 @@
   :group 'languages)
 
 (defconst silice-font-lock-keywords
-  '(("\\b\\(uninitialized\\|import\\|algorithm\\|input\\|output\\|inout\\|if\\|else\\|while\\|autorun\\|auto\\|onehot\\|\\+\\+:\\|brom\\|bram\\|dualport_bram\\|case\\|default\\|break\\|switch\\|circuitry\\|always\\|bitfield\\|interface\\)\\b"
+  '(("\\b\\(uninitiali\\(s|z\\)ed\\|import\\|algorithm\\|input\\|output\\|inout\\|if\\|else\\|while\\|autorun\\|auto\\|onehot\\|\\+\\+:\\|brom\\|bram\\|dualport_bram\\|case\\|default\\|break\\|switch\\|circuitry\\|always\\|bitfield\\|interface\\|subroutine\\|readwrites\\|reads\\|writes\\|calls\\)\\b"
      . font-lock-keyword-face)
     ;; keywords
     ("\\(@\\|!\\)\\([[:alpha:]]\\|_\\)\\([[:alnum:]]\\|_\\)+"
      . font-lock-function-name-face)
     ;; algorithm meta-specifiers
-    ("\\b\\(__\\(display\\|write\\|\\(un\\)?signed\\)\\)\\b"
+    ("\\b\\(__\\(display\\|write\\|\\(un\\)?signed\\)\\|widthof\\|sameas\\)\\b"
      . font-lock-builtin-face)
     ;; intrisics
     ("\\b\\(u?int\\([[:digit:]]+\\)?\\)\\b"

--- a/tools/emacs/silice-mode.el
+++ b/tools/emacs/silice-mode.el
@@ -14,12 +14,39 @@
   :link '(custom-group-link :tag "Font lock faces group" font-lock-faces)
   :group 'languages)
 
+(defconst silice-keywords
+  '("uninitialized"
+    "uninitialised"
+    "import"
+    "algorithm"
+    "input"
+    "output"
+    "inout"
+    "if" "else"
+    "while"
+    "autorun" "auto" "onehot"
+    "brom" "bram" "dualport_bram" "simple_dualport_bram"
+    "case" "switch" "default" "break"
+    "circuitry"
+    "always" "always_before" "always_after"
+    "bitfield" "interface" "subroutine" "group"
+    "readwrites" "reads" "writes" "calls"
+    "goto" "return"
+    "isdone")
+  "List of Silice keywords.")
+
+
 (defconst silice-font-lock-keywords
-  '(("\\(\\(\\$\\$[^\n]*?$\\)\\|\\(\\$include\\([^\n]*?\\)$\\)\\|\\(\\$[^z-a]*?\\$\\)\\)"
+  `(("\\(\\(\\$\\$[^\n]*?$\\)\\|\\(\\$include\\([^\n]*?\\)$\\)\\|\\(\\$[^z-a]*?\\$\\)\\)"
      0 font-lock-preprocessor-face prepend)
     ;; preprocessor
-    ("\\b\\(uninitiali\\(s|z\\)ed\\|import\\|algorithm\\|input\\|output\\|inout\\|if\\|else\\|while\\|autorun\\|auto\\|onehot\\|\\+\\+:\\|brom\\|bram\\|dualport_bram\\|case\\|default\\|break\\|switch\\|circuitry\\|always\\|bitfield\\|interface\\|subroutine\\|readwrites\\|reads\\|writes\\|calls\\)\\b"
-     . font-lock-keyword-face)
+    (,(concat "\\b\\("
+              (mapconcat 'identity
+                         silice-keywords
+                         "\\|"
+                         )
+              "\\)\\b")
+        . font-lock-keyword-face)
     ;; keywords
     ("\\(@\\|!\\)\\([[:alpha:]]\\|_\\)\\([[:alnum:]]\\|_\\)+"
      . font-lock-function-name-face)

--- a/tools/emacs/silice-mode.el
+++ b/tools/emacs/silice-mode.el
@@ -53,6 +53,8 @@
   "Syntax table used while in Silice mode.")
 
 ;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.ice\\.lpp\\'" . silice-mode))
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.ice\\'" . silice-mode))
 ;;;###autoload
 (define-derived-mode silice-mode prog-mode "Silice"

--- a/tools/emacs/silice-mode.el
+++ b/tools/emacs/silice-mode.el
@@ -64,7 +64,7 @@
     ;; strings
     ("[[:digit:]]+\\(b\\|h\\|d\\)[[:xdigit:]]+"
      . font-lock-constant-face)
-    ("[[:digit:]]+"
+    ("\\b[[:digit:]]+\\b"
      . font-lock-constant-face)
     ;; numbers
     )

--- a/tools/emacs/silice-mode.el
+++ b/tools/emacs/silice-mode.el
@@ -15,7 +15,10 @@
   :group 'languages)
 
 (defconst silice-font-lock-keywords
-  '(("\\b\\(uninitiali\\(s|z\\)ed\\|import\\|algorithm\\|input\\|output\\|inout\\|if\\|else\\|while\\|autorun\\|auto\\|onehot\\|\\+\\+:\\|brom\\|bram\\|dualport_bram\\|case\\|default\\|break\\|switch\\|circuitry\\|always\\|bitfield\\|interface\\|subroutine\\|readwrites\\|reads\\|writes\\|calls\\)\\b"
+  '(("\\(\\(\\$\\$[^\n]*?$\\)\\|\\(\\$include\\([^\n]*?\\)$\\)\\|\\(\\$[^z-a]*?\\$\\)\\)"
+     . font-lock-preprocessor-face)
+    ;; preprocessor
+    ("\\b\\(uninitiali\\(s|z\\)ed\\|import\\|algorithm\\|input\\|output\\|inout\\|if\\|else\\|while\\|autorun\\|auto\\|onehot\\|\\+\\+:\\|brom\\|bram\\|dualport_bram\\|case\\|default\\|break\\|switch\\|circuitry\\|always\\|bitfield\\|interface\\|subroutine\\|readwrites\\|reads\\|writes\\|calls\\)\\b"
      . font-lock-keyword-face)
     ;; keywords
     ("\\(@\\|!\\)\\([[:alpha:]]\\|_\\)\\([[:alnum:]]\\|_\\)+"
@@ -27,9 +30,6 @@
     ("\\b\\(u?int\\([[:digit:]]+\\)?\\)\\b"
      . font-lock-type-face)
     ;; builtin types
-    ("\\(\\(^\\$\\$\\(.\\|[[:space:]]\\)*?$\\)\\|\\(^\\$include\\(.*?\\)$\\)\\|\\(\\$[^z-a]*?\\$\\)\\)"
-     . font-lock-preprocessor-face)
-    ;; preprocessor
     ("\".*?\""
      . font-lock-string-face)
     ("'.*?'"
@@ -37,6 +37,9 @@
     ;; strings
     ("[[:digit:]]+\\(b\\|h\\|d\\)[[:xdigit:]]+"
      . font-lock-constant-face)
+    ("[[:digit:]]+"
+     . font-lock-constant-face)
+    ;; numbers
     )
   "Additional expressions to highlight in Silice mode.")
 
@@ -58,12 +61,12 @@
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.ice\\'" . silice-mode))
 ;;;###autoload
-(define-derived-mode silice-mode prog-mode "Silice"
+(define-derived-mode silice-mode fundamental-mode "Silice"
   "Major mode for editing simple Silice source files.
 Only provides syntax highlighting."
 
-  (setq-local font-lock-defaults '(silice-font-lock-keywords))
   (set-syntax-table (make-syntax-table silice-mode-syntax-table))
+  (setq-local font-lock-defaults '(silice-font-lock-keywords))
 
   (setq-local comment-start "//")
   (setq-local comment-add 1)

--- a/tools/emacs/silice-mode.el
+++ b/tools/emacs/silice-mode.el
@@ -46,6 +46,7 @@
     (modify-syntax-entry ?/  ". 124b" st)
     (modify-syntax-entry ?*  ". 23" st)
     (modify-syntax-entry ?_  "w" st)
+    (modify-syntax-entry ?$  "_" st)
 ;    (modify-syntax-entry ?\" "|" st)
 ;    (modify-syntax-entry ?'  "|" st)
 ;    NOTE: this somehow breaks the font locks defined for the preprocessor if they contain strings


### PR DESCRIPTION
Provides a emacs major mode to add syntax highlighting to `.ice` and `.ice.lpp` files.
Tested on emacs 27.2 but should work at least on emacs 23+: ![image](https://user-images.githubusercontent.com/22964017/116106210-5081b780-a6b2-11eb-911e-c7808f4f63e0.png)
