### PR TITLE
Fix ternary expression error reported in #130

### DIFF
--- a/src/Algorithm.cpp
+++ b/src/Algorithm.cpp
@@ -1681,10 +1681,10 @@ std::string Algorithm::rewriteExpression(
       } else if (term->getSymbol()->getType() == siliceParser::TOSIGNED) {
         return "$signed";
       } else {
-        return expr->getText();
+        return expr->getText() == "?" ? " ? " : expr->getText();
       }
     } else {
-      return expr->getText();
+      return expr->getText() == "?" ? " ? " : expr->getText();
     }
   } else {
     auto access = dynamic_cast<siliceParser::AccessContext*>(expr);

--- a/tests/issues/130_literal_ternary_condition.ice
+++ b/tests/issues/130_literal_ternary_condition.ice
@@ -1,0 +1,5 @@
+algorithm main(output uint$NUM_LEDS$ leds) {
+  uint1 b = 0;
+
+  b = 2b00 ? 1b1 : 1b0;
+}


### PR DESCRIPTION
Yosys triggers an error when the condition of a ternary expression ends with a string literal in Silice.

This is caused by the lack of spaces around the `?` token (yielding `2'b00?1'b0:1'b1` for example). Indeed, Verilog accepts `?` (as an equivalent to `Z`) in non-decimal number literals, which triggers a syntax error here (because `2'b00?1` is a single token).

This PR adds a minimal reproducible example, and also fixes this issue (the code yielded is now `2'b00 ? 1'b0:1'b1`, which successfully parses with Yosys).