### PR TITLE
Replicating bits without surrounding curly braces is now a syntax error

### DIFF
--- a/antlr/silice.g4
+++ b/antlr/silice.g4
@@ -281,9 +281,7 @@ unaryExpression     : (
                     '-' | '!' | '~&' | '~|' | '&' | '|' | '^~'| '~^' | '~'
 					) atom | atom ;
 
-concatexpr          : expression_0 | NUMBER concatenation ;
-
-concatenation       : '{' concatexpr (',' concatexpr)* '}' ;
+concatenation       : '{' (NUMBER concatenation | expression_0 (',' expression_0)*) '}';
 
 atom                : CONSTANT 
                     | NUMBER 

--- a/tests/issues/145_repbits_concat.ice
+++ b/tests/issues/145_repbits_concat.ice
@@ -1,0 +1,3 @@
+algorithm main(output uint8 leds) {
+  __display("%d", {8{1b1}, 5b11111});
+}


### PR DESCRIPTION
This fixes #145 by reporting such errors as Silice syntax errors:
![image](https://user-images.githubusercontent.com/22964017/125255148-6d19ad00-e2fb-11eb-91cd-5cfa5d43dad5.png)

A concatenation is now either:
- a repeat expression of the form `{<number>{<concat>}}` (where `<number>` and `<concat>` are production rules)
- a list of expressions of the form `{<expression>(',' <expression>)*}` (must have at least 1 child expression); note that an expression can also be a concatenation, so `{3b000, {2{1b1}}}` is valid

--------------------------

- [X] This change was tested against multiple projects in the Silice project base
- [X] No regression was found while testing