### PR TITLE
Preprocessor lines can now be empty

### DIFF
--- a/antlr/lpp.g4
+++ b/antlr/lpp.g4
@@ -40,7 +40,7 @@ LUALINE_PREFIX      : (' ' | '\t')* '$$' ;
 
 lualine     : LUALINE_PREFIX code=ANY?;
 
-luacode     : '$' code=ANY '$' ;
+luacode     : '$' code=ANY '$' | '$$' ;
 
 siliceincl  : INCLUDE filename=ANY; 
 

--- a/antlr/lpp.g4
+++ b/antlr/lpp.g4
@@ -32,13 +32,15 @@ NEWLINE             : ('\r'? '\n' | '\r') ;
 
 ANY                 : ~[\r\n$]+ ;
 
+ANY_NO_DOLLAR       : ~[\r\n]+;
+
 FILENAME            : '\'' (DIGIT|LETTERU|'.'|'/')* '\'' ;
 
 LUALINE_PREFIX      : (' ' | '\t')* '$$' ;
 
 /* ======== Parser ======== */
 
-lualine     : LUALINE_PREFIX code=ANY ;
+lualine     : LUALINE_PREFIX code=ANY_NO_DOLLAR? ;
 
 luacode     : '$' code=ANY '$' ;
 

--- a/antlr/lpp.g4
+++ b/antlr/lpp.g4
@@ -22,9 +22,11 @@ fragment LETTER     : [a-zA-Z_] ;
 fragment LETTERU    : [a-zA-Z_] ;
 fragment DIGIT      : [0-9] ;
 
-DISPLAY             : '$display' ~[\r\n]* ;
+DISPLAY             : WHITESPACE* '$display' ~[\r\n]* ;
+//                    ^^^^^^^^^^^ why tho???
 
-INCLUDE             : '$include' ;
+INCLUDE             : WHITESPACE* '$include' ;
+//                    ^^^^^^^^^^^ why tho???
 
 DOLLAR              : '$';
 DOUBLE_DOLLAR       : WHITESPACE* '$$';

--- a/antlr/lpp.g4
+++ b/antlr/lpp.g4
@@ -22,9 +22,13 @@ fragment LETTER     : [a-zA-Z_] ;
 fragment LETTERU    : [a-zA-Z_] ;
 fragment DIGIT      : [0-9] ;
 
-DISPLAY             : (' ' | '\t')* '$display' ~[\r\n]* ;
+DISPLAY             : '$display' ~[\r\n]* ;
 
-INCLUDE             : (' ' | '\t')* '$include' ;
+INCLUDE             : '$include' ;
+
+DOLLAR              : '$';
+DOUBLE_DOLLAR       : WHITESPACE* '$$';
+//                    ^^^^^^^^^^^ why tho???
 
 WHITESPACE          : (' ' | '\t') -> skip ;
 
@@ -34,13 +38,11 @@ ANY                 : ~[\r\n$]+ ;
 
 FILENAME            : '\'' (DIGIT|LETTERU|'.'|'/')* '\'' ;
 
-LUALINE_PREFIX      : (' ' | '\t')* '$$' ;
-
 /* ======== Parser ======== */
 
-lualine     : LUALINE_PREFIX code=ANY?;
+lualine     : DOUBLE_DOLLAR code=ANY;
 
-luacode     : '$' code=ANY '$' | '$$' ;
+luacode     : DOLLAR code=ANY? DOLLAR | DOUBLE_DOLLAR ;
 
 siliceincl  : INCLUDE filename=ANY; 
 

--- a/antlr/lpp.g4
+++ b/antlr/lpp.g4
@@ -32,15 +32,13 @@ NEWLINE             : ('\r'? '\n' | '\r') ;
 
 ANY                 : ~[\r\n$]+ ;
 
-ANY_NO_DOLLAR       : ~[\r\n]+;
-
 FILENAME            : '\'' (DIGIT|LETTERU|'.'|'/')* '\'' ;
 
 LUALINE_PREFIX      : (' ' | '\t')* '$$' ;
 
 /* ======== Parser ======== */
 
-lualine     : LUALINE_PREFIX code=ANY_NO_DOLLAR? ;
+lualine     : LUALINE_PREFIX code=ANY?;
 
 luacode     : '$' code=ANY '$' ;
 

--- a/src/LuaPreProcessor.cpp
+++ b/src/LuaPreProcessor.cpp
@@ -658,7 +658,7 @@ std::string LuaPreProcessor::processCode(
           code += luaProtectString(silcode->getText());
         }
         if (luacode) {
-          code += "' .. (" + luacode->code->getText() + ") .. '";
+          code += "' .. (" + (luacode->code ? luacode->code->getText() : "''") + ") .. '";
         }
       }
       code += "\\n'," + std::to_string(src_line-1) + "," + std::to_string(src_file_id) + ")\n";

--- a/src/LuaPreProcessor.cpp
+++ b/src/LuaPreProcessor.cpp
@@ -640,6 +640,7 @@ std::string LuaPreProcessor::processCode(
     // pre-process
     if (l->lualine() != nullptr) {
 
+      // code += l->lualine()->code->getText() + "\n";
       if (auto code_ = l->lualine()->code) {
         code += code_->getText() + "\n";
       } else {
@@ -657,8 +658,8 @@ std::string LuaPreProcessor::processCode(
         if (silcode) {
           code += luaProtectString(silcode->getText());
         }
-        if (luacode) {
-          code += "' .. (" + (luacode->code ? luacode->code->getText() : "''") + ") .. '";
+        if (luacode && luacode->code) {
+          code += "' .. (" + luacode->code->getText() + ") .. '";
         }
       }
       code += "\\n'," + std::to_string(src_line-1) + "," + std::to_string(src_file_id) + ")\n";

--- a/src/LuaPreProcessor.cpp
+++ b/src/LuaPreProcessor.cpp
@@ -640,7 +640,11 @@ std::string LuaPreProcessor::processCode(
     // pre-process
     if (l->lualine() != nullptr) {
 
-      code += l->lualine()->code->getText() + "\n";
+      if (auto code_ = l->lualine()->code) {
+        code += code_->getText() + "\n";
+      } else {
+        code += "\n";
+      }
 
     } else if (l->siliceline() != nullptr) {
 

--- a/tests/issues/18_empty_preproc_line.ice
+++ b/tests/issues/18_empty_preproc_line.ice
@@ -1,0 +1,5 @@
+$$
+algorithm main(output uint5 leds)
+{
+  leds = 1;
+} 

--- a/tests/issues/18_empty_preproc_line.ice
+++ b/tests/issues/18_empty_preproc_line.ice
@@ -1,5 +1,5 @@
 $$
-algorithm main(output uint5 leds)
+algorithm main(output uint8 leds)
 {
   leds = 1;
 } 

--- a/tests/issues/25_comment_preproc.ice
+++ b/tests/issues/25_comment_preproc.ice
@@ -1,0 +1,6 @@
+//$$TEST=0
+
+algorithm main(output uint1 leds)
+{
+
+}

--- a/tests/issues/25_comment_preproc.ice
+++ b/tests/issues/25_comment_preproc.ice
@@ -1,6 +1,6 @@
 //$$TEST=0
 
-algorithm main(output uint1 leds)
+algorithm main(output uint8 leds)
 {
 
 }


### PR DESCRIPTION
Fixes #18, where an empty preprocessor line is a syntax error, which leads to a silent fail to parse any following piece of code.
This code:
```
a
$$
b
c
d
e
```
was treated as 
```
a
<error>
```
because ANTLR failed to parse further than the unrecognized token sequence `$$\n`.