### PR TITLE
Better errors when output is bound multiple times

### DIFF
--- a/src/Algorithm.cpp
+++ b/src/Algorithm.cpp
@@ -4843,14 +4843,14 @@ void Algorithm::determineModAlgBoundVIO()
       if (b.dir == e_Right) {
         // check not already bound
         if (m_VIOBoundToModAlgOutputs.find(bindingRightIdentifier(b)) != m_VIOBoundToModAlgOutputs.end()) {
-          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module",b.right);
+          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module",std::get<std::string>(b.right).c_str());
         }
         // record wire name for this output
         m_VIOBoundToModAlgOutputs[bindingRightIdentifier(b)] = WIRE + im.second.instance_prefix + "_" + b.left;
       } else if (b.dir == e_BiDir) {
         // check not already bound
         if (m_VIOBoundToModAlgOutputs.find(bindingRightIdentifier(b)) != m_VIOBoundToModAlgOutputs.end()) {
-          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module", b.right);
+          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module", std::get<std::string>(b.right).c_str());
         }
         // record wire name for this inout
         std::string bindpoint = im.second.instance_prefix + "_" + b.left;
@@ -4864,14 +4864,14 @@ void Algorithm::determineModAlgBoundVIO()
       if (b.dir == e_Right) {
         // check not already bound
         if (m_VIOBoundToModAlgOutputs.find(bindingRightIdentifier(b)) != m_VIOBoundToModAlgOutputs.end()) {
-          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module", b.right);
+          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module", std::get<std::string>(b.right).c_str());
         }
         // record wire name for this output
         m_VIOBoundToModAlgOutputs[bindingRightIdentifier(b)] = WIRE + ia.second.instance_prefix + "_" + b.left;
       } else if (b.dir == e_BiDir) {
         // check not already bound
         if (m_VIOBoundToModAlgOutputs.find(bindingRightIdentifier(b)) != m_VIOBoundToModAlgOutputs.end()) {
-          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module", b.right);
+          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module", std::get<std::string>(b.right).c_str());
         }
         // record wire name for this inout
         std::string bindpoint = ia.second.instance_prefix + "_" + b.left;

--- a/src/Algorithm.cpp
+++ b/src/Algorithm.cpp
@@ -4843,14 +4843,14 @@ void Algorithm::determineModAlgBoundVIO()
       if (b.dir == e_Right) {
         // check not already bound
         if (m_VIOBoundToModAlgOutputs.find(bindingRightIdentifier(b)) != m_VIOBoundToModAlgOutputs.end()) {
-          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module",std::get<std::string>(b.right).c_str());
+          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module",bindingRightIdentifier(b).c_str());
         }
         // record wire name for this output
         m_VIOBoundToModAlgOutputs[bindingRightIdentifier(b)] = WIRE + im.second.instance_prefix + "_" + b.left;
       } else if (b.dir == e_BiDir) {
         // check not already bound
         if (m_VIOBoundToModAlgOutputs.find(bindingRightIdentifier(b)) != m_VIOBoundToModAlgOutputs.end()) {
-          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module", std::get<std::string>(b.right).c_str());
+          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module", bindingRightIdentifier(b).c_str());
         }
         // record wire name for this inout
         std::string bindpoint = im.second.instance_prefix + "_" + b.left;
@@ -4864,14 +4864,14 @@ void Algorithm::determineModAlgBoundVIO()
       if (b.dir == e_Right) {
         // check not already bound
         if (m_VIOBoundToModAlgOutputs.find(bindingRightIdentifier(b)) != m_VIOBoundToModAlgOutputs.end()) {
-          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module", std::get<std::string>(b.right).c_str());
+          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module", bindingRightIdentifier(b).c_str());
         }
         // record wire name for this output
         m_VIOBoundToModAlgOutputs[bindingRightIdentifier(b)] = WIRE + ia.second.instance_prefix + "_" + b.left;
       } else if (b.dir == e_BiDir) {
         // check not already bound
         if (m_VIOBoundToModAlgOutputs.find(bindingRightIdentifier(b)) != m_VIOBoundToModAlgOutputs.end()) {
-          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module", std::get<std::string>(b.right).c_str());
+          reportError(nullptr, (int)b.line, "vio '%s' is already bound as the output of another algorithm or module", bindingRightIdentifier(b).c_str());
         }
         // record wire name for this inout
         std::string bindpoint = ia.second.instance_prefix + "_" + b.left;


### PR DESCRIPTION
<details><summary><b>Simple code to reproduce the issue</b></summary>

```c
algorithm A(output uint8 x) {
  x = 3;
}

algorithm main(output uint5 leds) {
  uint8 W = uninitialized;

  A a(x :> W);
  A b(x :> W);
}
```

</details>

The error reported by the Silice compiler for such errors used to be: 
![image](https://user-images.githubusercontent.com/22964017/125406715-6f424100-e3b9-11eb-9fbf-3b8b105c3b59.png)
`+` should in fact be `W`. This is because the parameter given to the exception should have been a `char *`, but was some sort of `std::variant<...>` which cannot be output using a `%s` formatter.

---------------------------------

This PR fixes that, giving better/correct errors:
![image](https://user-images.githubusercontent.com/22964017/125407298-06a79400-e3ba-11eb-9a46-201deaf7101d.png)
