### PR TITLE
Return from algorithm

### DIFF
--- a/tests/return_in_algorithm.ice
+++ b/tests/return_in_algorithm.ice
@@ -1,0 +1,11 @@
+algorithm main(output uint8 leds) {
+  uint8 cnt = 0;
+  
+  while (cnt < 200) {
+    if (cnt == 156) {
+      return;
+    }
+    
+    cnt = cnt + 1;
+  }
+}


### PR DESCRIPTION
Implements #138.

Using `return` in an algorithm allows jumping directly to the terminal state of its FSM, may there be one.
When the algorithm does not contain any FSM, an error is issued.

#### Example:
```c
algorithm main(output uint8 leds) {
  uint8 cnt = 0;
  
  leds := cnt;

  while (cnt < 200) {
    if (cnt == 156) {
      return;
    }

    cnt = cnt + 1;
  }
}
```
The counter `cnt` will not go higher than `156`.