### PR TITLE
Update float32 to latest

### DIFF
--- a/projects/common/float32.ice
+++ b/projects/common/float32.ice
@@ -42,6 +42,38 @@
 //
 // NB: Error states are those required by Risc-V floating point
 
+// CLZ CIRCUITS - TRANSLATED BY @sylefeb
+// From recursive Verilog module
+// https://electronics.stackexchange.com/questions/196914/verilog-synthesize-high-speed-leading-zero-count
+
+// Create a LUA pre-processor function that recursively writes
+// circuitries counting the number of leading zeros in variables
+// of decreasing width.
+// Note: this could also be made in-place without wrapping in a
+// circuitry, directly outputting a hierarchical set of trackers (<:)
+$$function generate_clz(name,w_in,recurse)
+$$ local w_out = clog2(w_in)
+$$ local w_h   = w_in//2
+$$ if w_in > 2 then generate_clz(name,w_in//2,1) end
+circuitry $name$_$w_in$ (input in,output out)
+{
+$$ if w_in == 2 then
+   out = ~in[1,1];
+$$ else
+   uint$clog2(w_in)-1$ half_count = uninitialized;
+   uint$w_h$           lhs        <: in[$w_h$,$w_h$];
+   uint$w_h$           rhs        <: in[    0,$w_h$];
+   uint$w_h$           select     <: left_empty ? rhs : lhs;
+   uint1               left_empty <: ~|lhs;
+   (half_count) = $name$_$w_h$(select);
+   out          = {left_empty,half_count};
+$$ end
+}
+$$end
+
+// Produce a circuit for 32 bits numbers ( and 16, 8, 4, 2 )
+$$generate_clz('clz_silice',32)
+
 // BITFIELD FOR FLOATING POINT NUMBER - IEEE-754 32 bit format
 bitfield fp32{
     uint1   sign,
@@ -49,6 +81,7 @@ bitfield fp32{
     uint23  fraction
 }
 
+// REFERENCE, NOT USED IN THIS MODULE
 bitfield floatingpointflags{
     uint1   IF,     // infinity as an argument
     uint1   NN,     // NaN as an argument
@@ -66,80 +99,88 @@ algorithm classify(
     output  uint1   sNAN,
     output  uint1   qNAN,
     output  uint1   ZERO
-) <autorun> {
-    uint1   expFF <:: ( fp32(a).exponent == 8hff );
+) <autorun,reginputs> {
+    // CHECK FOR 8hff
+    uint1   expFF <:: &fp32(a).exponent;
+    uint1   NAN <:: expFF & a[22,1];
+
     always {
         INF = expFF & ~a[22,1];
-        sNAN = expFF & a[22,1] & a[21,1];
-        qNAN = expFF & a[22,1] & ~a[21,1];
-        ZERO = ( fp32(a).exponent == 0 );
+        sNAN = NAN & a[21,1];
+        qNAN = NAN & ~a[21,1];
+        ZERO = ~|( fp32(a).exponent );
     }
 }
 
-// ALGORITHMS TO DEAL WITH 48 BIT FRACTIONS TO 23 BIT FRACTIONS
-// NORMALISE A 48 BIT MANTISSA SO THAT THE MSB IS ONE
-// FOR ADDSUB ALSO DECREMENT THE EXPONENT FOR EACH SHIFT LEFT
-algorithm donormalise48_adjustexp(
+// NORMALISE A 48 BIT MANTISSA SO THAT THE MSB IS ONE, FOR ADDSUB ALSO DECREMENT THE EXPONENT FOR EACH SHIFT LEFT
+// EXTRACT THE 24 BITS FOLLOWING THE MSB (1.xxxx) FOR ROUNDING
+algorithm clz48(
+    input   uint48  bitstream,
+    output  uint48  normalised,
+    output! uint6   count
+) <autorun,reginputs> {
+    uint16  bitstreamh <:: bitstream[32,16];
+    uint32  bitstreaml <:: bitstream[0,32];
+    uint1   zerohigh <:: ( ~|bitstreamh );
+    uint6   clz = uninitialised;
+    always {
+        if( zerohigh ) {
+            ( clz ) = clz_silice_32( bitstreaml );
+            count = 16 + clz;
+        } else {
+            ( count ) = clz_silice_16( bitstreamh );
+        }
+    }
+}
+algorithm donormalise24_adjustexp(
     input   uint1   start,
     output  uint1   busy(0),
     input   int10   exp,
     input   uint48  bitstream,
     output  int10   newexp,
-    output  uint48  normalised
-) <autorun> {
-    uint4   shiftcount <:: { normalised[33,15] == 0, normalised[41,7] == 0, normalised[45,3] == 0, 1b1 };
-    while(1) {
+    output  uint24  normalised
+) <autorun,reginputs> {
+    // COUNT LEADING ZEROS
+    clz48 CLZ48( bitstream <: bitstream );
+    uint48  temporary <:: bitstream << CLZ48.count;
+    always {
         if( start ) {
             busy = 1;
-            normalised = bitstream; newexp = exp;
-            while( ~normalised[47,1] ) {
-                switch( shiftcount ) {
-                    default: { normalised = { normalised[0,47], 1b0 }; }
-                    case 3: { normalised = { normalised[0,45], 3b0 }; }
-                    case 7: { normalised = { normalised[0,41], 7b0 }; }
-                    case 15: { normalised = { normalised[0,33], 15b0 }; }
-                }
-                newexp = newexp - shiftcount;
-            }
+            normalised = temporary[23,24];
+            newexp = exp - CLZ48.count;
             busy = 0;
         }
     }
 }
-algorithm donormalise48(
+algorithm donormalise24(
     input   uint1   start,
     output  uint1   busy(0),
     input   uint48  bitstream,
-    output  uint48  normalised
-) <autorun> {
-    uint4   shiftcount <:: { normalised[33,15] == 0, normalised[41,7] == 0, normalised[45,3] == 0, 1b1 };
-    while(1) {
+    output  uint24  normalised
+) <autorun,reginputs> {
+    // COUNT LEADING ZEROS
+    clz48 CLZ48( bitstream <: bitstream );
+    uint48  temporary <:: bitstream << CLZ48.count;
+    always {
         if( start ) {
             busy = 1;
-            normalised = bitstream;
-            while( ~normalised[47,1] ) {
-                switch( shiftcount ) {
-                    default: { normalised = { normalised[0,47], 1b0 }; }
-                    case 3: { normalised = { normalised[0,45], 3b0 }; }
-                    case 7: { normalised = { normalised[0,41], 7b0 }; }
-                    case 15: { normalised = { normalised[0,33], 15b0 }; }
-                }
-            }
+            normalised = temporary[23,24];
             busy = 0;
         }
     }
 }
 
-// EXTRACT 23 BIT FRACTION FROM LEFT ALIGNED 48 BIT FRACTION WITH ROUNDING
+// ROUND 23 BIT FRACTION FROM NORMALISED FRACTION USING NEXT TRAILING BIT
 // ADD BIAS TO EXPONENT AND ADJUST EXPONENT IF ROUNDING FORCES
-algorithm doround48(
-    input   uint48  bitstream,
+algorithm doround24(
+    input   uint24  bitstream,
     input   int10   exponent,
     output  uint23  roundfraction,
     output  int10   newexponent
-) <autorun> {
+) <autorun,reginputs> {
     always {
-        roundfraction = bitstream[24,23] + bitstream[23,1];
-        newexponent = 127 + exponent + ( ( roundfraction == 0 ) & bitstream[23,1] );
+        roundfraction = bitstream[1,23] + bitstream[0,1];
+        newexponent = 127 + exponent + ( ( ~|roundfraction ) & bitstream[23,1] );
     }
 }
 
@@ -152,58 +193,62 @@ algorithm docombinecomponents32(
     output  uint1   OF,
     output  uint1   UF,
     output  uint32  f32
-) <autorun> {
+) <autorun,reginputs> {
     always {
         OF = ( exp > 254 ); UF = exp[9,1];
-        f32 = UF ? 0 : OF ? { sign, 8b11111111, 23h0 } : { sign, exp[0,8], fraction[0,23] };
+        f32 = UF ? 0 : OF ? { sign, 31h7f800000 } : { sign, exp[0,8], fraction[0,23] };
     }
 }
 
 // CONVERT SIGNED/UNSIGNED INTEGERS TO FLOAT
 // dounsigned == 1 for signed conversion (31 bit plus sign), == 0 for dounsigned conversion (32 bit)
+algorithm clz32(
+    input   uint32  bitstream,
+    output! uint6   zeros
+) <autorun,reginputs> {
+    always {
+        ( zeros ) = clz_silice_32( bitstream );
+    }
+}
 algorithm inttofloat(
-    input   uint1   start,
-    output  uint1   busy(0),
     input   uint32  a,
     input   uint1   dounsigned,
     output  uint7   flags,
     output  uint32  result
-) <autorun> {
+) <autorun,reginputs> {
+    // CHECK FOR 24, 16 OR 8 LEADING ZEROS, CONTINUE COUNTING FROM THERE
+    clz32 CLZ32( bitstream <: number );
     uint1   sign <:: dounsigned ? 0 : a[31,1];
-    uint8   zeros = uninitialised;
     uint32  number <:: dounsigned ? a : ( a[31,1] ? -a : a );
-    uint32  fraction <:: NX ? number >> ( 8 - zeros ) : ( zeros > 8 ) ? number << ( zeros - 8 ) : number;
-    int10   exponent <:: 158 - zeros;
+    uint32  fraction <:: NX ? number >> ( 8 - CLZ32.zeros ) : ( CLZ32.zeros > 8 ) ? number << ( CLZ32.zeros - 8 ) : number;
+    int10   exponent <:: 158 - CLZ32.zeros;
     uint1   OF = uninitialised; uint1 UF = uninitialised; uint1 NX = uninitialised;
 
-    uint1   cOF = uninitialised;
-    uint1   cUF = uninitialised;
-    uint32  f32 = uninitialised;
-    docombinecomponents32 COMBINE(
-        sign <: sign,
-        exp <: exponent,
-        fraction <: fraction,
-        OF :> cOF,
-        UF :> cUF,
-        f32 :> f32
-    );
+    docombinecomponents32 COMBINE( sign <: sign, exp <: exponent, fraction <: fraction );
+
     flags := { 4b0, OF, UF, NX };
 
-    while(1) {
-        if( start ) {
-            busy = 1;
-            OF = 0; UF = 0; NX = 0;
-            switch( number ) {
-                case 0: { result = 0; }
-                default: {
-                    // CHECK FOR 24, 16 OR 8 LEADING ZEROS, CONTINUE COUNTING FROM THERE
-                    zeros = number[8,24] == 0 ? 24 : number[16,16] == 0 ? 16 : number[24,8] == 0 ? 8 : 0; while( ~number[31-zeros,1] ) { zeros = zeros + 1; } NX = ( zeros < 8 );
-                    ++:
-                    OF = cOF; UF = cUF; result = f32;
-                }
-            }
-            busy = 0;
+    always {
+        OF = 0; UF = 0; NX = 0;
+        if( ~|number ) {
+            result = 0;
+        } else {
+            NX = ( CLZ32.zeros < 8 );
+            OF = COMBINE.OF; UF = COMBINE.UF; result = COMBINE.f32;
         }
+    }
+}
+
+// BREAK DOWN FLOAT READY FOR CONVERSION TO INTEGER
+algorithm prepftoi(
+    input   uint32  a,
+    output  int10   exp,
+    output  uint32  unsignedfraction
+) <autorun,reginputs> {
+    uint33  sig <:: ( exp < 24 ) ? { 9b1, fp32( a ).fraction, 1b0 } >> ( 23 - exp ) : { 9b1, fp32( a ).fraction, 1b0 } << ( exp - 24);
+    always {
+        exp = fp32( a ).exponent - 127;
+        unsignedfraction = ( sig[1,32] + sig[0,1] );
     }
 }
 
@@ -212,29 +257,19 @@ algorithm floattoint(
     input   uint32  a,
     output  uint7   flags,
     output  uint32  result
-) <autorun> {
-    int10   exp <:: fp32( a ).exponent - 127;
-    uint33  sig <:: ( exp < 24 ) ? { 9b1, fp32( a ).fraction, 1b0 } >> ( 23 - exp ) : { 9b1, fp32( a ).fraction, 1b0 } << ( exp - 24);
-    uint1   IF <:: aINF;
-    uint1   NN <:: asNAN | aqNAN;
+) <autorun,reginputs> {
+    // CLASSIFY THE INPUT
+    uint1   NN <:: A.sNAN | A.qNAN;
     uint1   NV = uninitialised;
+    classify A( a <: a );
 
-    uint1   aINF = uninitialised;
-    uint1   asNAN = uninitialised;
-    uint1   aqNAN = uninitialised;
-    uint1   aZERO = uninitialised;
-    classify A(
-        a <: a,
-        INF :> aINF,
-        sNAN :> asNAN,
-        qNAN :> aqNAN,
-        ZERO :> aZERO
-    );
+    // PREPARE THE CONVERSION
+    prepftoi PREP( a <: a );
 
-    flags := { IF, NN, NV, 4b0000 };
+    flags := { A.INF, NN, NV, 4b0000 };
     always {
-        switch( { IF | NN, aZERO } ) {
-            case 2b00: { NV = ( exp > 30 ); result = NV ? { fp32( a ).sign, 31h7fffffff } : fp32( a ).sign ? -( sig[1,32] + sig[0,1] ) : ( sig[1,32] + sig[0,1] ); }
+        switch( { A.INF | NN, A.ZERO } ) {
+            case 2b00: { NV = ( PREP.exp > 30 ); result = NV ? { fp32( a ).sign, 31h7fffffff } : fp32( a ).sign ? -PREP.unsignedfraction : PREP.unsignedfraction; }
             case 2b01: { NV = 0; result = 0; }
             default: { NV = 1; result = NN ? 32h7fffffff : { fp32( a ).sign, 31h7fffffff }; }
         }
@@ -246,34 +281,21 @@ algorithm floattouint(
     input   uint32  a,
     output  uint7   flags,
     output  uint32  result
-) <autorun> {
-    int10   exp <:: fp32( a ).exponent - 127;
-    uint33  sig <:: ( exp < 24 ) ? { 9b1, fp32( a ).fraction, 1b0 } >> ( 23 - exp ) : { 9b1, fp32( a ).fraction, 1b0 } << ( exp - 24);
-    uint1   IF <:: aINF;
-    uint1   NN <:: asNAN | aqNAN;
+) <autorun,reginputs> {
+    // CLASSIFY THE INPUT
+    uint1   NN <:: A.sNAN | A.qNAN;
     uint1   NV = uninitialised;
+    classify A( a <: a );
 
-    uint1   aINF = uninitialised;
-    uint1   asNAN = uninitialised;
-    uint1   aqNAN = uninitialised;
-    uint1   aZERO = uninitialised;
-    classify A(
-        a <: a,
-        INF :> aINF,
-        sNAN :> asNAN,
-        qNAN :> aqNAN,
-        ZERO :> aZERO
-    );
+    // PREPARE THE CONVERSION
+    prepftoi PREP( a <: a );
 
-    flags := { IF, NN, NV, 4b0000 };
+    flags := { A.INF, NN, NV, 4b0000 };
     always {
-        switch( { IF | NN, aZERO } ) {
+        switch( { A.INF | NN, A.ZERO } ) {
             case 2b00: {
-                if( fp32( a ).sign ) {
-                    NV = 1; result = 0;
-                } else {
-                    NV = ( exp > 31 ); result = NV ? 32hffffffff : ( sig[1,32] + sig[0,1] );
-                }
+                NV = ( fp32( a ).sign ) | ( PREP.exp > 31 );
+                result = ( fp32( a ).sign ) ? 0 : NV ? 32hffffffff : PREP.unsignedfraction;
             }
             case 2b01: { NV = 0; result = 0; }
             default: { NV = 1; result = NN ? 32hffffffff : { {32{~fp32( a ).sign}} };  }
@@ -287,17 +309,16 @@ algorithm equaliseexpaddsub(
     input   uint48  sigA,
     input   int10   expB,
     input   uint48  sigB,
-    output  int10   newexpA,
     output  uint48  newsigA,
-    output  int10   newexpB,
-    output  uint48  newsigB
-) <autorun> {
+    output  uint48  newsigB,
+    output  int10   resultexp,
+) <autorun,reginputs> {
     always {
-        // EQUALISE THE EXPONENTS BY SHIFT SMALLER NUMBER FRACTION PART TO THE RIGHT
+        // EQUALISE THE EXPONENTS BY SHIFT SMALLER NUMBER FRACTION PART TO THE RIGHT - REMOVE BIAS ( AND +1 TO ACCOUNT FOR POTENTIAL OVERFLOW )
         if( expA < expB ) {
-            newsigA = sigA >> ( expB - expA ); newexpA = expB; newsigB = sigB; newexpB = expB;
+            newsigA = sigA >> ( expB - expA ); resultexp = expB - 126; newsigB = sigB;
         } else {
-            newsigB = sigB >> ( expA - expB ); newexpB = expA; newsigA = sigA; newexpA = expA;
+            newsigB = sigB >> ( expA - expB ); resultexp = expA - 126; newsigA = sigA;
         }
     }
 }
@@ -308,16 +329,17 @@ algorithm dofloataddsub(
     input   uint48  sigB,
     output  uint1   resultsign,
     output  uint48  resultfraction
-) <autorun> {
+) <autorun,reginputs> {
     uint48  sigAminussigB <:: sigA - sigB;
     uint48  sigBminussigA <:: sigB - sigA;
+    uint48  sigAplussigB <:: sigA + sigB;
 
     always {
         // PERFORM ADDITION HANDLING SIGNS
         switch( { signA, signB } ) {
             case 2b01: { resultsign = ( sigB > sigA ); resultfraction = resultsign ? sigBminussigA : sigAminussigB; }
             case 2b10: { resultsign = ( sigA > sigB ); resultfraction = resultsign ? sigAminussigB : sigBminussigA; }
-            default: { resultsign = signA; resultfraction = sigA + sigB; }
+            default: { resultsign = signA; resultfraction = sigAplussigB; }
         }
     }
 }
@@ -330,132 +352,57 @@ algorithm floataddsub(
     input   uint1   addsub,
     output  uint7   flags,
     output  uint32  result
-) <autorun> {
+) <autorun,reginputs> {
     // BREAK DOWN INITIAL float32 INPUTS - SWITCH SIGN OF B IF SUBTRACTION
-    uint1   signA <:: fp32( a ).sign;
-    int10   expA <:: fp32( a ).exponent - 127;
     uint48  sigA <:: { 2b01, fp32(a).fraction, 23b0 };
     uint1   signB <:: addsub ? ~fp32( b ).sign : fp32( b ).sign;
-    int10   expB <:: fp32( b ).exponent - 127;
     uint48  sigB <:: { 2b01, fp32(b).fraction, 23b0 };
 
     // CLASSIFY THE INPUTS AND FLAG INFINITY, NAN, ZERO AND INVALID ( INF - INF )
-    uint1   IF <:: ( aINF | bINF );
-    uint1   NN <:: ( asNAN | aqNAN | bsNAN | bqNAN );
-    uint1   NV <:: ( aINF & bINF) & ( signA != signB );
+    uint1   IF <:: ( A.INF | B.INF );
+    uint1   NN <:: ( A.sNAN | A.qNAN | B.sNAN | B.qNAN );
+    uint1   NV <:: ( A.INF & B.INF) & ( fp32( a ).sign ^ signB );
     uint1   OF = uninitialised;
     uint1   UF = uninitialised;
-
-    uint1   aINF = uninitialised;
-    uint1   asNAN = uninitialised;
-    uint1   aqNAN = uninitialised;
-    uint1   aZERO = uninitialised;
-    classify A(
-        a <: a,
-        INF :> aINF,
-        sNAN :> asNAN,
-        qNAN :> aqNAN,
-        ZERO :> aZERO
-    );
-    uint1   bINF = uninitialised;
-    uint1   bsNAN = uninitialised;
-    uint1   bqNAN = uninitialised;
-    uint1   bZERO = uninitialised;
-    classify B(
-        a <: b,
-        INF :> bINF,
-        sNAN :> bsNAN,
-        qNAN :> bqNAN,
-        ZERO :> bZERO
-    );
+    classify A( a <: a );
+    classify B( a <: b );
 
     // EQUALISE THE EXPONENTS
-    int10   eqexpA = uninitialised;
-    uint48  eqsigA = uninitialised;
-    int10   eqexpB = uninitialised;
-    uint48  eqsigB = uninitialised;
-    equaliseexpaddsub EQUALISEEXP(
-        expA <: expA,
-        sigA <: sigA,
-        expB <: expB,
-        sigB <: sigB,
-        newexpA :> eqexpA,
-        newsigA :> eqsigA,
-        newexpB :> eqexpB,
-        newsigB :> eqsigB
-    );
+    equaliseexpaddsub EQUALISEEXP( expA <: fp32( a ).exponent, sigA <: sigA,  expB <: fp32( b ).exponent, sigB <: sigB );
 
     // PERFORM THE ADDITION/SUBTRACION USING THE EQUALISED FRACTIONS, 1 IS ADDED TO THE EXPONENT IN CASE OF OVERFLOW - NORMALISING WILL ADJUST WHEN SHIFTING
-    uint1   resultsign = uninitialised;
-    int10   resultexp <:: eqexpA + 1;
-    uint48  resultfraction = uninitialised;
-    dofloataddsub ADDSUB(
-        signA <: signA,
-        sigA <: eqsigA,
-        signB <: signB,
-        sigB <: eqsigB,
-        resultsign :> resultsign,
-        resultfraction :> resultfraction
-    );
+    dofloataddsub ADDSUB( signA <: fp32( a ).sign, sigA <: EQUALISEEXP.newsigA, signB <: signB, sigB <: EQUALISEEXP.newsigB );
 
     // NORMALISE THE RESULTING FRACTION AND ADJUST THE EXPONENT IF SMALLER ( ie, MSB is not 1 )
-    int10   normalexp = uninitialised;
-    uint48  normalfraction = uninitialised;
-    uint1   NORMALISEstart = uninitialised;
-    uint1   NORMALISEbusy = uninitialised;
-    donormalise48_adjustexp NORMALISE(
-        exp <: resultexp,
-        bitstream <: resultfraction,
-        newexp :> normalexp,
-        normalised :> normalfraction,
-        start <: NORMALISEstart,
-        busy :> NORMALISEbusy
-    );
+    donormalise24_adjustexp NORMALISE( exp <: EQUALISEEXP.resultexp, bitstream <: ADDSUB.resultfraction );
 
     // ROUND THE NORMALISED FRACTION AND ADJUST EXPONENT IF OVERFLOW
-    int10   roundexponent = uninitialised;
-    uint48  roundfraction = uninitialised;
-    doround48 ROUND(
-        exponent <: normalexp,
-        bitstream <: normalfraction,
-        newexponent :> roundexponent,
-        roundfraction :> roundfraction
-    );
+    doround24 ROUND( exponent <: NORMALISE.newexp, bitstream <: NORMALISE.normalised );
 
     // COMBINE TO FINAL float32
-    uint1   cOF = uninitialised;
-    uint1   cUF = uninitialised;
-    uint32  f32 = uninitialised;
-    docombinecomponents32 COMBINE(
-        sign <: resultsign,
-        exp <: roundexponent,
-        fraction <: roundfraction,
-        OF :> cOF,
-        UF :> cUF,
-        f32 :> f32
-    );
+    docombinecomponents32 COMBINE( sign <: ADDSUB.resultsign, exp <: ROUND.newexponent, fraction <: ROUND.roundfraction );
 
-    NORMALISEstart := 0; flags := { IF, NN, NV, 1b0, OF, UF, 1b0 };
+    NORMALISE.start := 0; flags := { IF, NN, NV, 1b0, OF, UF, 1b0 };
     while(1) {
         if( start ) {
             busy = 1;
             OF = 0; UF = 0;
-            ++: // ALLOW 2 CYCLES FOR EQUALISING EXPONENTS AND TO PERFORM THE ADDITION/SUBTRACTION
-            ++:
-            switch( { IF | NN, aZERO | bZERO } ) {
+            ++: // ALLOW 1 CYCLES FOR CLASSIFICATION AND EQUALISING EXPONENTS
+            switch( { IF | NN, A.ZERO | B.ZERO } ) {
                 case 2b00: {
-                    switch( resultfraction ) {
-                        case 0: { result = 0; }
-                        default: {
-                            NORMALISEstart = 1; while( NORMALISEbusy ) {}
-                            OF = cOF; UF = cUF; result = f32;
-                        }
+                    ++: // ALLOW 1 CYCLE TO PERFORM THE ADDITION/SUBTRACTION
+                    if( ~|ADDSUB.resultfraction ) {
+                        result = 0;
+                    } else {
+                        NORMALISE.start = 1; while( NORMALISE.busy ) {}
+                        ++:
+                        OF = COMBINE.OF; UF = COMBINE.UF; result = COMBINE.f32;
                     }
                 }
-                case 2b01: { result = ( aZERO & bZERO ) ? 0 : ( bZERO ) ? a : addsub ? { ~fp32( b ).sign, b[0,31] } : b; }
+                case 2b01: { result = ( A.ZERO & B.ZERO ) ? 0 : ( B.ZERO ) ? a : addsub ? { ~fp32( b ).sign, b[0,31] } : b; }
                 default: {
                     switch( { IF, NN } ) {
-                        case 2b10: { result = ( aINF & bINF) ? ( signA == signB ) ? a : 32hffc00000 : aINF ? a : b; }
+                        case 2b10: { result = ( A.INF & B.INF) ? ( fp32( a ).sign ~^ signB ) ? a : 32hffc00000 : A.INF ? a : b; }
                         default: { result = 32hffc00000; }
                     }
                 }
@@ -466,13 +413,21 @@ algorithm floataddsub(
 }
 
 // UNSIGNED / SIGNED 24 by 24 bit multiplication giving 48 bit product using DSP blocks
-algorithm dofloatmul(
-    input   uint24  factor_1,
-    input   uint24  factor_2,
-    output  uint48  product
-) <autorun> {
+// NORMALISE AND EXTRACT THE NORMALISED FRACTION FOR ROUNDING
+algorithm prepmul(
+    input   uint32  a,
+    input   uint32  b,
+    output  uint1   productsign,
+    output  int10   productexp,
+    output  uint24  normalfraction
+) <autorun,reginputs> {
+    uint24  sigA <:: { 1b1, fp32( a ).fraction };
+    uint24  sigB <:: { 1b1, fp32( b ).fraction };
+    uint48  product <:: sigA * sigB;
     always {
-        product = factor_1 * factor_2;
+        productsign = fp32( a ).sign ^ fp32( b ).sign;
+        productexp = fp32( a ).exponent + fp32( b ).exponent - 254 + product[47,1];
+        normalfraction = product[47,1] ? product[23,24] : product[22,24];
     }
 }
 algorithm floatmultiply(
@@ -483,93 +438,45 @@ algorithm floatmultiply(
 
     output  uint7   flags,
     output  uint32  result
-) <autorun> {
+) <autorun,reginputs> {
     // BREAK DOWN INITIAL float32 INPUTS AND FIND SIGN OF RESULT AND EXPONENT OF PRODUCT ( + 1 IF PRODUCT OVERFLOWS, MSB == 1 )
-    uint1   productsign <:: fp32( a ).sign ^ fp32( b ).sign;
-    int10   productexp <:: (fp32( a ).exponent - 127) + (fp32( b ).exponent - 127) + product[47,1];
-    uint24  sigA <:: { 1b1, fp32( a ).fraction };
-    uint24  sigB <:: { 1b1, fp32( b ).fraction };
+    // NORMALISE THE RESULTING PRODUCT AND EXTRACT THE 24 BITS AFTER THE LEADING 1.xxxx
+    prepmul PREP( a <: a, b <: b );
 
     // CLASSIFY THE INPUTS AND FLAG INFINITY, NAN, ZERO AND INVALID ( INF x ZERO )
-    uint1   IF <:: ( aINF | bINF );
-    uint1   NN <:: ( asNAN | aqNAN | bsNAN | bqNAN );
-    uint1   NV <:: ( aINF | bINF ) & ( aZERO | bZERO );
+    uint1   ZERO <:: ( A.ZERO | B.ZERO );
+    uint1   IF <:: ( A.INF | B.INF );
+    uint1   NN <:: ( A.sNAN | A.qNAN | B.sNAN | B.qNAN );
+    uint1   NV <:: IF & ZERO;
     uint1   OF = uninitialised;
     uint1   UF = uninitialised;
+    classify A( a <: a );
+    classify B( a <: b  );
 
-    uint1   aINF = uninitialised;
-    uint1   asNAN = uninitialised;
-    uint1   aqNAN = uninitialised;
-    uint1   aZERO = uninitialised;
-    classify A(
-        a <: a,
-        INF :> aINF,
-        sNAN :> asNAN,
-        qNAN :> aqNAN,
-        ZERO :> aZERO
-    );
-    uint1   bINF = uninitialised;
-    uint1   bsNAN = uninitialised;
-    uint1   bqNAN = uninitialised;
-    uint1   bZERO = uninitialised;
-    classify B(
-        a <: b,
-        INF :> bINF,
-        sNAN :> bsNAN,
-        qNAN :> bqNAN,
-        ZERO :> bZERO
-    );
-
-    uint48  product = uninitialised;
-    dofloatmul UINTMUL(
-        factor_1 <: sigA,
-        factor_2 <: sigB,
-        product :> product
-    );
-
-    // FAST NORMALISATION - MULTIPLICATION RESULTS IN 1x.xxx or 01.xxxx
-    uint48  normalfraction <:: product[47,1] ? product : { product[0,47], 1b0 };
-
-    int10   roundexponent = uninitialised;
-    uint48  roundfraction = uninitialised;
-    doround48 ROUND(
-        exponent <: productexp,
-        bitstream <: normalfraction,
-        newexponent :> roundexponent,
-        roundfraction :> roundfraction
-    );
+    // ROUND THE NORMALISED FRACTION AND ADJUST EXPONENT IF OVERFLOW
+    doround24 ROUND( exponent <: PREP.productexp, bitstream <: PREP.normalfraction );
 
     // COMBINE TO FINAL float32
-    uint1   cOF = uninitialised;
-    uint1   cUF = uninitialised;
-    uint32  f32 = uninitialised;
-    docombinecomponents32 COMBINE(
-        sign <: productsign,
-        exp <: roundexponent,
-        fraction <: roundfraction,
-        OF :> cOF,
-        UF :> cUF,
-        f32 :> f32
-    );
+    docombinecomponents32 COMBINE( sign <: PREP.productsign, exp <: ROUND.newexponent, fraction <: ROUND.roundfraction );
 
     flags := { IF, NN, NV, 1b0, OF, UF, 1b0 };
     while(1) {
         if( start ) {
             busy = 1;
             OF = 0; UF = 0;
-            ++: // ALLOW 3 CYLES TO PERFORM THE MULTIPLICATION, NORMALISATION AND ROUNDING
-            ++:
-            ++:
-            switch( { IF | NN, aZERO | bZERO } ) {
+            ++: // ALLOW 1 CYCLE TO PERFORM CALSSIFICATIONS
+            switch( { IF | NN, ZERO } ) {
                 case 2b00: {
                     // STEPS: SETUP -> DOMUL -> NORMALISE -> ROUND -> ADJUSTEXP -> COMBINE
-                    OF = cOF; UF = cUF; result = f32;
+                    ++: // ALLOW 2 CYCLES TO PERFORM THE MULTIPLICATION, NORMALISATION AND ROUNDING
+                    ++:
+                    OF = COMBINE.OF; UF = COMBINE.UF; result = COMBINE.f32;
                 }
-                case 2b01: { result = { productsign, 31b0 }; }
+                case 2b01: { result = { PREP.productsign, 31b0 }; }
                 default: {
-                    switch( { IF, aZERO | bZERO } ) {
+                    switch( { IF, ZERO } ) {
                         case 2b11: { result = 32hffc00000; }
-                        case 2b10: { result = NN ? 32hffc00000 : { productsign, 8b11111111, 23b0 }; }
+                        case 2b10: { result = NN ? 32hffc00000 : { PREP.productsign, 31h7f800000 }; }
                         default: { result = 32hffc00000; }
                     }
                 }
@@ -586,24 +493,45 @@ algorithm dofloatdivide(
     input   uint50  sigA,
     input   uint50  sigB,
     output  uint50  quotient
-) <autorun> {
+) <autorun,reginputs> {
     uint50  remainder = uninitialised;
     uint50  temporary <:: { remainder[0,49], sigA[bit,1] };
     uint1   bitresult <:: __unsigned(temporary) >= __unsigned(sigB);
     uint6   bit(63);
+    uint2   normalshift <:: ( quotient[48,1] + quotient[49,1] );
 
-    busy := start | ( bit != 63 ) | ( quotient[48,2] != 0 );
+    busy := start | ( ~&bit ) | ( |quotient[48,2] );
     while(1) {
         // FIND QUOTIENT AND ENSURE 48 BIT FRACTION ( ie BITS 48 and 49 clear )
         if( start ) {
             bit = 49; quotient = 0; remainder = 0;
-            while( bit != 63 ) {
+            while( busy ) {
                 remainder = __unsigned(temporary) - ( bitresult ? __unsigned(sigB) : 0 );
                 quotient[bit,1] = bitresult;
                 bit = bit - 1;
             }
-            while( quotient[48,2] != 00 ) { quotient = quotient >> 1; }
+            quotient = quotient >> normalshift;
         }
+    }
+}
+algorithm prepdivide(
+    input   uint32  a,
+    input   uint32  b,
+    output  uint1   quotientsign,
+    output  int10   quotientexp,
+    output  uint50  sigA,
+    output  uint50  sigB
+) <autorun,reginputs> {
+    // BREAK DOWN INITIAL float32 INPUTS AND FIND SIGN OF RESULT AND EXPONENT OF QUOTIENT ( -1 IF DIVISOR > DIVIDEND )
+    // ALIGN DIVIDEND TO THE LEFT, DIVISOR TO THE RIGHT
+    int10   expA <:: fp32( a ).exponent - 127;
+    int10   expB <:: fp32( b ).exponent - 127;
+    uint1   AvB <:: ( fp32(b).fraction > fp32(a).fraction );
+    always {
+        quotientsign = fp32( a ).sign ^ fp32( b ).sign;
+        quotientexp = expA - expB - AvB;
+        sigA = { 1b1, fp32(a).fraction, 26b0 };
+        sigB = { 27b1, fp32(b).fraction };
     }
 }
 
@@ -612,103 +540,43 @@ algorithm floatdivide(
     output  uint1   busy(0),
     input   uint32  a,
     input   uint32  b,
-
     output  uint7   flags,
     output  uint32  result
-) <autorun> {
-    // BREAK DOWN INITIAL float32 INPUTS AND FIND SIGN OF RESULT AND EXPONENT OF QUOTIENT ( -1 IF DIVISOR > DIVIDEND )
-    uint1   quotientsign <:: fp32( a ).sign ^ fp32( b ).sign;
-    int10   quotientexp <:: ((fp32( a ).exponent - 127) - (fp32( b ).exponent - 127)) - ( fp32(b).fraction > fp32(a).fraction );
-    uint50  sigA <:: { 1b1, fp32(a).fraction, 26b0 };
-    uint50  sigB <:: { 27b1, fp32(b).fraction };
-
+) <autorun,reginputs> {
     // CLASSIFY THE INPUTS AND FLAG INFINITY, NAN, ZERO AND DIVIDE ZERO
-    uint1   IF <:: ( aINF | bINF );
-    uint1   NN <:: ( asNAN | aqNAN | bsNAN | bqNAN );
+    uint1   IF <:: ( A.INF | B.INF );
+    uint1   NN <:: ( A.sNAN | A.qNAN | B.sNAN | B.qNAN );
     uint1   NV = uninitialised;
-    uint1   DZ <:: bZERO;
     uint1   OF = uninitialised;
     uint1   UF = uninitialised;
+    classify A( a <: a );
+    classify B( a <: b );
 
-    uint1   aINF = uninitialised;
-    uint1   asNAN = uninitialised;
-    uint1   aqNAN = uninitialised;
-    uint1   aZERO = uninitialised;
-    classify A(
-        a <: a,
-        INF :> aINF,
-        sNAN :> asNAN,
-        qNAN :> aqNAN,
-        ZERO :> aZERO
-    );
-    uint1   bINF = uninitialised;
-    uint1   bsNAN = uninitialised;
-    uint1   bqNAN = uninitialised;
-    uint1   bZERO = uninitialised;
-    classify B(
-        a <: b,
-        INF :> bINF,
-        sNAN :> bsNAN,
-        qNAN :> bqNAN,
-        ZERO :> bZERO
-    );
+    // PREPARE THE DIVISION, DO THE DIVISION, NORMALISE THE RESULT
+    prepdivide PREP( a <: a, b <: b );
+    dofloatdivide DODIVIDE( sigA <: PREP.sigA, sigB <: PREP.sigB );
+    donormalise24 NORMALISE( bitstream <: DODIVIDE.quotient );
 
-    uint48  quotient = uninitialised;
-    uint1   DODIVIDEstart = uninitialised;
-    uint1   DODIVIDEbusy = uninitialised;
-    dofloatdivide DODIVIDE(
-        sigA <: sigA,
-        sigB <: sigB,
-        quotient :> quotient,
-        start <: DODIVIDEstart,
-        busy :> DODIVIDEbusy
-    );
-
-    uint48  normalfraction = uninitialised;
-    uint1   NORMALISEstart = uninitialised;
-    uint1   NORMALISEbusy = uninitialised;
-    donormalise48 NORMALISE(
-        bitstream <: quotient,
-        normalised :> normalfraction,
-        start <: NORMALISEstart,
-        busy :> NORMALISEbusy
-    );
-
-    int10   roundexponent = uninitialised;
-    uint48  roundfraction = uninitialised;
-    doround48 ROUND(
-        exponent <: quotientexp,
-        bitstream <: normalfraction,
-        newexponent :> roundexponent,
-        roundfraction :> roundfraction
-    );
+    // ROUND THE NORMALISED FRACTION AND ADJUST EXPONENT IF OVERFLOW
+    doround24 ROUND( exponent <: PREP.quotientexp, bitstream <: NORMALISE.normalised );
 
     // COMBINE TO FINAL float32
-    uint1   cOF = uninitialised;
-    uint1   cUF = uninitialised;
-    uint32  f32 = uninitialised;
-    docombinecomponents32 COMBINE(
-        sign <: quotientsign,
-        exp <: roundexponent,
-        fraction <: roundfraction,
-        OF :> cOF,
-        UF :> cUF,
-        f32 :> f32
-    );
+    docombinecomponents32 COMBINE( sign <: PREP.quotientsign, exp <: ROUND.newexponent, fraction <: ROUND.roundfraction );
 
-    DODIVIDEstart := 0; NORMALISEstart := 0; flags := { IF, NN, 1b0, DZ, OF, UF, 1b0};
+    DODIVIDE.start := 0; NORMALISE.start := 0; flags := { IF, NN, 1b0, B.ZERO, OF, UF, 1b0};
     while(1) {
         if( start ) {
             busy = 1;
             OF = 0; UF = 0;
-            switch( { IF | NN, aZERO | bZERO } ) {
+            switch( { IF | NN, A.ZERO | B.ZERO } ) {
                 case 2b00: {
-                    DODIVIDEstart = 1; while( DODIVIDEbusy ) {}
-                    NORMALISEstart = 1; while( NORMALISEbusy ) {}
-                    OF = cOF; UF = cUF; result = f32;
+                    DODIVIDE.start = 1; while( DODIVIDE.busy ) {}
+                    NORMALISE.start = 1; while( NORMALISE.busy ) {}
+                    ++:
+                    OF = COMBINE.OF; UF = COMBINE.UF; result = COMBINE.f32;
                 }
-                case 2b01: { result = ( aZERO & bZERO ) ? 32hffc00000 : ( bZERO ) ? { quotientsign, 8b11111111, 23b0 } : { quotientsign, 31b0 }; }
-                default: { result = ( aINF &bINF ) | NN | bZERO ? 32hffc00000 : aZERO | bINF ? { quotientsign, 31b0 } : { quotientsign, 8b11111111, 23b0 }; }
+                case 2b01: { result = ( A.ZERO & B.ZERO ) ? 32hffc00000 : ( B.ZERO ) ? { PREP.quotientsign, 31h7f800000 } : { PREP.quotientsign, 31b0 }; }
+                default: { result = ( A.INF & B.INF ) | NN | B.ZERO ? 32hffc00000 : A.ZERO | B.INF ? { PREP.quotientsign, 31b0 } : { PREP.quotientsign, 31h7f800000 }; }
             }
             busy = 0;
         }
@@ -744,9 +612,9 @@ algorithm dofloatsqrt(
     output  uint1   busy(0),
     input   uint50  start_ac,
     input   uint48  start_x,
-    output  uint48  q
-) <autorun> {
-    uint50  test_res <:: ac - { q, 2b01 };
+    output  uint48  squareroot
+) <autorun,reginputs> {
+    uint50  test_res <:: ac - { squareroot, 2b01 };
     uint50  ac = uninitialised;
     uint48  x = uninitialised;
     uint6   i(47);
@@ -754,14 +622,30 @@ algorithm dofloatsqrt(
     busy := start | ( i != 47 );
     while(1) {
         if( start ) {
-            i = 0; q = 0; ac = start_ac; x = start_x;
-            while( i != 47 ) {
+            i = 0; squareroot = 0; ac = start_ac; x = start_x;
+            while( busy ) {
                 ac = { test_res[49,1] ? ac[0,47] : test_res[0,47], x[46,2] };
-                q = { q[0,47], ~test_res[49,1] };
+                squareroot = { squareroot[0,47], ~test_res[49,1] };
                 x = { x[0,46], 2b00 };
                 i = i + 1;
             }
         }
+    }
+}
+algorithm prepsqrt(
+    input   uint32  a,
+    output  uint50  start_ac,
+    output  uint48  start_x,
+    output  int10   squarerootexp
+) <autorun,reginputs> {
+    // EXPONENT OF INPUT ( used to determine if 1x.xxxxx or 01.xxxxx for fixed point fraction to sqrt )
+    // SQUARE ROOT EXPONENT IS HALF OF INPUT EXPONENT
+    int10   exp  <:: fp32( a ).exponent - 127;
+    always {
+        // SIGN OF INPUT
+        start_ac = exp[0,1] ? { 48b0, 1b1, a[22,1] } : 1;
+        start_x = exp[0,1] ? { a[0,22], 26b0 } : { fp32( a ).fraction, 25b0 };
+        squarerootexp = ( exp >>> 1 );
     }
 }
 
@@ -771,87 +655,44 @@ algorithm floatsqrt(
     input   uint32  a,
     output  uint7   flags,
     output  uint32  result
-) <autorun> {
-    uint1   sign <:: fp32( a ).sign;             // SIGN OF INPUT
-    int10   exp  <:: fp32( a ).exponent - 127;   // EXPONENT OF INPUT ( used to determine if 1x.xxxxx or 01.xxxxx for fixed point fraction to sqrt )
-
+) <autorun,reginputs> {
     // CLASSIFY THE INPUTS AND FLAG INFINITY, NAN, ZERO AND NOT VALID
-    uint1   IF <:: aINF;
-    uint1   NN <:: asNAN | aqNAN;
-    uint1   NV <:: IF | NN | sign;
+    uint1   NN <:: A.sNAN | A.qNAN;
+    uint1   NV <:: A.INF | NN | fp32( a ).sign;
     uint1   OF = uninitialised;
     uint1   UF = uninitialised;
+    classify A( a <: a );
 
-    uint1   aINF = uninitialised;
-    uint1   asNAN = uninitialised;
-    uint1   aqNAN = uninitialised;
-    uint1   aZERO = uninitialised;
-    classify A(
-        a <: a,
-        INF :> aINF,
-        sNAN :> asNAN,
-        qNAN :> aqNAN,
-        ZERO :> aZERO
-    );
-
-    // SQUARE ROOT EXPONENT IS HALF OF INPUT EXPONENT
-    uint50  start_ac <:: ~exp[0,1] ? 1 : { 48b0, 1b1, a[22,1] };
-    uint48  start_x <:: ~exp[0,1] ? { fp32( a ).fraction, 25b0 } : { a[0,22], 26b0 };
-    uint48  squareroot = uninitialised;
-    int10   squarerootexp <:: ( exp >>> 1 );
-    uint1   DOSQRTstart = uninitialised;
-    uint1   DOSQRTbusy = uninitialised;
-    dofloatsqrt DOSQRT(
-        start_ac <: start_ac,
-        start_x <: start_x,
-        q :> squareroot,
-        start <: DOSQRTstart,
-        busy :> DOSQRTbusy
-    );
+    // PREPARE AND PERFORM THE SQUAREROOT
+    prepsqrt PREP( a <: a );
+    dofloatsqrt DOSQRT( start_ac <: PREP.start_ac, start_x <: PREP.start_x );
 
     // FAST NORMALISATION - SQUARE ROOT RESULTS IN 1x.xxx or 01.xxxx
-    uint48  normalfraction <:: squareroot[47,1] ? squareroot : { squareroot[0,47], 1b0 };
-
-    int10   roundexponent = uninitialised;
-    uint48  roundfraction = uninitialised;
-    doround48 ROUND(
-        exponent <: squarerootexp,
-        bitstream <: normalfraction,
-        newexponent :> roundexponent,
-        roundfraction :> roundfraction
-    );
+    // EXTRACT 24 BITS FOR ROUNDING FOLLOWING THE NORMALISED 1.xxxx
+    uint24  normalfraction <::DOSQRT.squareroot[47,1] ? DOSQRT.squareroot[23,24] : DOSQRT.squareroot[22,24];
+    doround24 ROUND( exponent <: PREP.squarerootexp, bitstream <: normalfraction );
 
     // COMBINE TO FINAL float32
-    uint1   cOF = uninitialised;
-    uint1   cUF = uninitialised;
-    uint32  f32 = uninitialised;
-    docombinecomponents32 COMBINE(
-        sign <: sign,
-        exp <: roundexponent,
-        fraction <: roundfraction,
-        OF :> cOF,
-        UF :> cUF,
-        f32 :> f32
-    );
+    docombinecomponents32 COMBINE( sign <: fp32( a ).sign, exp <: ROUND.newexponent, fraction <: ROUND.roundfraction );
 
-    DOSQRTstart := 0; flags := { IF, NN, NV, 1b0, OF, UF, 1b0 };
+    DOSQRT.start := 0; flags := { A.INF, NN, NV, 1b0, OF, UF, 1b0 };
     while(1) {
         if( start ) {
             busy = 1;
             OF = 0; UF = 0;
-            switch( { IF | NN, aZERO } ) {
+            switch( { A.INF | NN, A.ZERO } ) {
                 case 2b00: {
-                    if( sign ) {
+                    if( fp32( a ).sign ) {
                         // DETECT NEGATIVE -> qNAN
                         result = 32hffc00000;
                     } else {
                         // STEPS: SETUP -> DOSQRT -> NORMALISE -> ROUND -> ADJUSTEXP -> COMBINE
-                        DOSQRTstart = 1; while( DOSQRTbusy ) {}
-                        OF = cOF; UF = cUF; result = f32;
+                        DOSQRT.start = 1; while( DOSQRT.busy ) {}
+                        OF = COMBINE.OF; UF = COMBINE.UF; result = COMBINE.f32;
                     }
                 }
                 // DETECT sNAN, qNAN, -INF, -0 -> qNAN AND  INF -> INF, 0 -> 0
-                default: { result = sign ? 32hffc00000 : a; }
+                default: { result = fp32( a ).sign ? 32hffc00000 : a; }
             }
             busy = 0;
         }
@@ -903,43 +744,22 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 algorithm floatcompare(
     input   uint32  a,
     input   uint32  b,
-    output  uint1   less,
     output  uint7   flags,
+    output  uint1   less,
     output  uint1   equal
-) <autorun> {
-    uint1   aINF = uninitialised;
-    uint1   asNAN = uninitialised;
-    uint1   aqNAN = uninitialised;
-    uint1   aZERO = uninitialised;
-    classify A(
-        a <: a,
-        INF :> aINF,
-        sNAN :> asNAN,
-        qNAN :> aqNAN,
-        ZERO :> aZERO
-    );
-    uint1   bINF = uninitialised;
-    uint1   bsNAN = uninitialised;
-    uint1   bqNAN = uninitialised;
-    uint1   bZERO = uninitialised;
-    classify B(
-        a <: b,
-        INF :> bINF,
-        sNAN :> bsNAN,
-        qNAN :> bqNAN,
-        ZERO :> bZERO
-    );
+) <autorun,reginputs> {
+    // CLASSIFY THE INPUTS AND DETECT INFINITY OR NAN
+    classify A( a <: a );
+    classify B( a <: b );
+    uint1   INF <:: A.INF | B.INF;
+    uint1   NAN <:: A.sNAN | B.sNAN | A.qNAN | B.qNAN;
+
+    uint1   aequalb <:: ( a == b );
+    uint1   aorbleft1equal0 <:: ~|( ( a | b ) << 1 );
+    uint1   avb <:: ( a < b );
 
     // IDENTIFY NaN, RETURN 0 IF NAN, OTHERWISE RESULT OF COMPARISONS
-    always {
-        flags = { aINF | bINF, asNAN | bsNAN | aqNAN | bqNAN, asNAN | bsNAN | aqNAN | bqNAN, 4b0000 };
-        if( flags[5,1] ) {
-            // NAN
-            less = 0;
-            equal = 0;
-        } else {
-            less = ( fp32( a ).sign != fp32( b ).sign ) ? fp32( a ).sign & ((( a | b ) << 1) != 0 ) : ( a != b ) & ( fp32( a ).sign ^ ( a < b));
-            equal = ( a == b ) | ((( a | b ) << 1) == 0 );
-        }
-    }
+    flags := { INF, {2{NAN}}, 4b0000 };
+    less := NAN ? 0 : ( ( fp32( a ).sign ^ fp32( b ).sign ) ? fp32( a ).sign & ~aorbleft1equal0 : ~aequalb & ( fp32( a ).sign ^ avb ) );
+    equal := NAN ? 0 : ( aequalb | aorbleft1equal0 );
 }


### PR DESCRIPTION
Update float32 to the latest more optimised version.

Make better use of verilog reduction operators. Once normalised only use the 24 bits of the fraction that are required to build the final result, plus 1 trailing bit for rounding.