### PR TITLE
Add missing <list> header.

### DIFF
--- a/src/Algorithm.h
+++ b/src/Algorithm.h
@@ -36,6 +36,7 @@ See GitHub Issues section for open/known issues.
 #include "TypesAndConsts.h"
 #include "Blueprint.h"
 
+#include <list>
 #include <string>
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
This PR fix compile issues with latest gcc.

---

The error before:
```
src/Algorithm.h:581:10: error: ‘list’ in namespace ‘std’ does not name a template type
```

```
$ gcc -v
Using built-in specs.
{....}
gcc version 12.1.1 20220507 (Red Hat 12.1.1-1) (GCC) 
```

Thanks,
~Cristian.