### PR TITLE
Updates for ULX3S and dualport_bram_wmask_byte support

### DIFF
--- a/frameworks/boards/ulx3s/board.json
+++ b/frameworks/boards/ulx3s/board.json
@@ -17,7 +17,8 @@
         {"set"    : "uart",    "define" : "UART=1"},
         {"set"    : "uart2",   "define" : "UART2=1"},
         {"set"    : "spiflash","define" : "SPIFLASH=1"},
-        {"set"    : "us2_ps2", "define" : "US2_PS2=1"}
+        {"set"    : "us2_ps2", "define" : "US2_PS2=1"},
+        {"set"    : "i2c",     "define" : "I2C=1"}
       ],
       "builders": [
       {
@@ -57,7 +58,8 @@
         {"set"    : "audio",  "define" : "AUDIO=1"},
         {"set"    : "uart",   "define" : "UART=1"},
         {"set"    : "uart2",  "define" : "UART2=1"},
-        {"set"    : "us2_ps2","define" : "US2_PS2=1"}
+        {"set"    : "us2_ps2","define" : "US2_PS2=1"},
+        {"set"    : "i2c",    "define" : "I2C=1"}
       ],
       "builders": [
       {
@@ -97,7 +99,8 @@
         {"set"    : "audio",  "define" : "AUDIO=1"},
         {"set"    : "uart",   "define" : "UART=1"},
         {"set"    : "uart2",  "define" : "UART2=1"},
-        {"set"    : "us2_ps2","define" : "US2_PS2=1"}
+        {"set"    : "us2_ps2","define" : "US2_PS2=1"},
+        {"set"    : "i2c",    "define" : "I2C=1"}
       ],
       "builders": [
       {
@@ -137,7 +140,8 @@
         {"set"    : "audio",  "define" : "AUDIO=1"},
         {"set"    : "uart",   "define" : "UART=1"},
         {"set"    : "uart2",  "define" : "UART2=1"},
-        {"set"    : "us2_ps2","define" : "US2_PS2=1"}
+        {"set"    : "us2_ps2","define" : "US2_PS2=1"},
+        {"set"    : "i2c",    "define" : "I2C=1"}
       ],
       "builders": [
       {
@@ -371,6 +375,18 @@
         "name": "us2_bd_dn",
         "type": "uint1",
         "io"  : "input"
+      }
+    ],
+    "i2c": [
+      {
+        "name": "gpdi_sda",
+        "type": "uint1",
+        "io"  : "inout"
+      },
+      {
+        "name": "gpdi_scl",
+        "type": "uint1",
+        "io"  : "inout"
       }
     ],
     "vga": [

--- a/frameworks/boards/ulx3s/ulx3s.v
+++ b/frameworks/boards/ulx3s/ulx3s.v
@@ -109,6 +109,11 @@ module top(
   output flash_mosi,
   input  flash_miso,
 `endif
+`ifdef I2C
+  // i2c for rtc
+  inout gpdi_sda,
+  inout gpdi_scl,
+`endif
   output wifi_gpio0,
   input  clk_25mhz
   );
@@ -258,6 +263,10 @@ M_main __main(
 `endif
 `ifdef HDMI
   .out_gpdi_dp  (__main_out_gpdi_dp),
+`endif
+`ifdef I2C
+  .inout_gpdi_sda(gpdi_sda),
+  .inout_gpdi_scl(gpdi_scl),
 `endif
   .clock         (clk_25mhz)
 );

--- a/frameworks/templates/dualport_bram_wmask_byte.v.in
+++ b/frameworks/templates/dualport_bram_wmask_byte.v.in
@@ -1,0 +1,31 @@
+// SL 2019, MIT license
+module %MODULE%(
+input      [%WENABLE0_WIDTH%-1:0]             in_%NAME%_wenable0,
+input      %DATA_TYPE% [%DATA_WIDTH%-1:0]     in_%NAME%_wdata0,
+input      [%ADDR0_WIDTH%-1:0]                in_%NAME%_addr0,
+input      [%WENABLE1_WIDTH%-1:0]             in_%NAME%_wenable1,
+input      [%DATA_WIDTH%-1:0]                 in_%NAME%_wdata1,
+input      [%ADDR1_WIDTH%-1:0]                in_%NAME%_addr1,
+output reg %DATA_TYPE% [%DATA_WIDTH%-1:0]     out_%NAME%_rdata0,
+output reg %DATA_TYPE% [%DATA_WIDTH%-1:0]     out_%NAME%_rdata1,
+input      %CLOCK%0,
+input      %CLOCK%1
+);
+(* no_rw_check *) reg %DATA_TYPE% [%DATA_WIDTH%-1:0] buffer[%DATA_SIZE%-1:0];
+always @(posedge %CLOCK%0) begin
+  out_%NAME%_rdata0 <= buffer[in_%NAME%_addr0];
+  out_%NAME%_rdata1 <= buffer[in_%NAME%_addr1];
+end
+integer i;
+always @(posedge %CLOCK%0) begin
+  for (i = 0; i < (%DATA_WIDTH%)/8; i = i + 1) begin
+    if (in_%NAME%_wenable0[i]) begin
+      buffer[in_%NAME%_addr0][i*8+:8] <= in_%NAME%_wdata0[i*8+:8];
+    end
+    if (in_%NAME%_wenable1[i]) begin
+      buffer[in_%NAME%_addr1][i*8+:8] <= in_%NAME%_wdata1[i*8+:8];
+    end
+  end
+end
+%INITIAL%
+endmodule


### PR DESCRIPTION
Update ULX3S to enable selection of I2C pins, for the real time clock support.

Add "missing" dualport_bram_wmask_byte support.
