### PR TITLE
Update GetStarted_macOS.md to latest brew package names

### DIFF
--- a/GetStarted_macOS.md
+++ b/GetStarted_macOS.md
@@ -6,7 +6,7 @@ Make sure to have python3 and the package termcolor installed
 
 ## Compiling Silice
 
-Install the following packages: `default-jre default-jdk git uuid ossp-uuid`, then:
+Install the following packages: `java git ossp-uuid`, then:
 
 ```
 git clone --recurse-submodules https://github.com/sylefeb/Silice.git


### PR DESCRIPTION
default-jre, default-jdk and uuid brew packages do not seem to exist anymore...