### PR TITLE
Add python3-pip to install_dependencies_fedora.sh

### DIFF
--- a/install_dependencies_fedora.sh
+++ b/install_dependencies_fedora.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo dnf install -y git gcc g++ make cmake pkg-config uuid uuid-devel java-11-openjdk-devel iverilog glfw glfw-devel gcc-riscv64-linux-gnu perl-FindBin python3
+sudo dnf install -y git gcc g++ make cmake pkg-config uuid uuid-devel java-11-openjdk-devel iverilog glfw glfw-devel gcc-riscv64-linux-gnu perl-FindBin python3 python3-pip


### PR DESCRIPTION
In Fedora, pip3 is not installed automatically with python3 but rather it's a separate dependency. Since the install script depends on it, it should probably be included in the dependencies for the project.

I'm not sure which branch I should target with this PR as it doesn't really affect the code so I just targeted the master branch for now, but please do point it out if I should merge into something else