### PR TITLE
Add --needed flag to prevent reinstalls on Arch Linux

### DIFF
--- a/install_dependencies_archlinux.sh
+++ b/install_dependencies_archlinux.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-pacman -S jdk-openjdk git gcc make cmake pkg-config glfw riscv64-linux-gnu-gcc python3
+pacman --needed -S jdk-openjdk git gcc make cmake pkg-config glfw riscv64-linux-gnu-gcc python3


### PR DESCRIPTION
Without the `--needed` flag the installer will reinstall all packages even if they are up to date.